### PR TITLE
[Feat/#25] 수기 작성 시 캘린더 요일값 전달

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeInfoFragment.kt
@@ -8,6 +8,8 @@ import androidx.fragment.app.Fragment
 import com.example.momolabfe.R
 import com.example.momolabfe.data.remote.record.model.DayWeek
 import com.example.momolabfe.databinding.FragmentRecordExchangeInfoBinding
+import com.example.momolabfe.utils.korean
+import com.example.momolabfe.utils.toDayWeek
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -50,26 +52,5 @@ class RecordExchangeInfoFragment : Fragment() {
                 .addToBackStack(null)
                 .commit()
         }
-    }
-
-    private fun DayWeek.korean(): String = when (this) {
-        DayWeek.MON -> "(월)"
-        DayWeek.TUE -> "(화)"
-        DayWeek.WED -> "(수)"
-        DayWeek.THU -> "(목)"
-        DayWeek.FRI -> "(금)"
-        DayWeek.SAT -> "(토)"
-        DayWeek.SUN -> "(일)"
-    }
-
-    // DayOfWeek → DayWeek 매핑
-    private fun DayOfWeek.toDayWeek(): DayWeek = when (this) {
-        DayOfWeek.MONDAY    -> DayWeek.MON
-        DayOfWeek.TUESDAY   -> DayWeek.TUE
-        DayOfWeek.WEDNESDAY -> DayWeek.WED
-        DayOfWeek.THURSDAY  -> DayWeek.THU
-        DayOfWeek.FRIDAY    -> DayWeek.FRI
-        DayOfWeek.SATURDAY  -> DayWeek.SAT
-        DayOfWeek.SUNDAY    -> DayWeek.SUN
     }
 }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeInfoFragment.kt
@@ -6,7 +6,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.example.momolabfe.R
+import com.example.momolabfe.data.remote.record.model.DayWeek
 import com.example.momolabfe.databinding.FragmentRecordExchangeInfoBinding
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -29,11 +31,18 @@ class RecordExchangeInfoFragment : Fragment() {
         // 전달된 날짜 문자열 꺼내기 (기본값: 오늘 날짜 포맷 or 빈 문자열)
         val dateText = arguments?.getString("selected_date_text")
             ?: LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy년 M월 d일"))
+        val dwKorean = arguments?.getString("selected_date_dw")
+            ?.let { DayWeek.valueOf(it).korean() }
+            ?: LocalDate.now().dayOfWeek.toDayWeek().korean()
 
         binding.dateTv.text = dateText
+        binding.dwTv.text = dwKorean
 
         binding.searchBtn.setOnClickListener {
-            val args = Bundle().apply { putString("selected_date_text", dateText) }
+            val args = Bundle().apply {
+                putString("selected_date_text", dateText)
+                putString("selected_date_dw", dwKorean)
+            }
             val fragment = RecordExchangeListFragment().apply { arguments = args }
 
             parentFragmentManager.beginTransaction()
@@ -41,6 +50,26 @@ class RecordExchangeInfoFragment : Fragment() {
                 .addToBackStack(null)
                 .commit()
         }
+    }
 
+    private fun DayWeek.korean(): String = when (this) {
+        DayWeek.MON -> "(월)"
+        DayWeek.TUE -> "(화)"
+        DayWeek.WED -> "(수)"
+        DayWeek.THU -> "(목)"
+        DayWeek.FRI -> "(금)"
+        DayWeek.SAT -> "(토)"
+        DayWeek.SUN -> "(일)"
+    }
+
+    // DayOfWeek → DayWeek 매핑
+    private fun DayOfWeek.toDayWeek(): DayWeek = when (this) {
+        DayOfWeek.MONDAY    -> DayWeek.MON
+        DayOfWeek.TUESDAY   -> DayWeek.TUE
+        DayOfWeek.WEDNESDAY -> DayWeek.WED
+        DayOfWeek.THURSDAY  -> DayWeek.THU
+        DayOfWeek.FRIDAY    -> DayWeek.FRI
+        DayOfWeek.SATURDAY  -> DayWeek.SAT
+        DayOfWeek.SUNDAY    -> DayWeek.SUN
     }
 }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeListFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeListFragment.kt
@@ -60,7 +60,10 @@ class RecordExchangeListFragment : Fragment() {
         val dateText = arguments?.getString("selected_date_text")
             ?: LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy년 M월 d일"))
         val dwKorean = arguments?.getString("selected_date_dw")
-            ?: weekdayShortKorean(LocalDate.now().dayOfWeek)
+            ?: "(${weekdayShortKorean(LocalDate.now().dayOfWeek)})"
+
+        binding.dateTv.text = dateText
+        binding.dwTv.text = dwKorean
 
         // 넘겨준 이미지 Uri로 OCR 호출
         val imageUri: Uri? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeListFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeListFragment.kt
@@ -17,6 +17,8 @@ import com.example.momolabfe.databinding.FragmentRecordExchangeListBinding
 import com.example.momolabfe.ui.record.adapter.ExchangeInfoAdapter
 import com.example.momolabfe.ui.record.data.RecordExchangeInfo
 import com.example.momolabfe.ui.record.viewModel.RecordViewModel
+import com.example.momolabfe.utils.korean
+import com.example.momolabfe.utils.weekdayShortKorean
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -78,26 +80,6 @@ class RecordExchangeListFragment : Fragment() {
         binding.exchangeRv.layoutManager = GridLayoutManager(requireContext(), 2)
         exchangeInfoAdapter = ExchangeInfoAdapter(mutableListOf())
         binding.exchangeRv.adapter = exchangeInfoAdapter
-    }
-
-    private fun DayWeek.korean(): String = when (this) {
-        DayWeek.MON -> "(월)"
-        DayWeek.TUE -> "(화)"
-        DayWeek.WED -> "(수)"
-        DayWeek.THU -> "(목)"
-        DayWeek.FRI -> "(금)"
-        DayWeek.SAT -> "(토)"
-        DayWeek.SUN -> "(일)"
-    }
-
-    private fun weekdayShortKorean(dow: DayOfWeek): String = when (dow) {
-        DayOfWeek.SUNDAY -> "일"
-        DayOfWeek.MONDAY -> "월"
-        DayOfWeek.TUESDAY -> "화"
-        DayOfWeek.WEDNESDAY -> "수"
-        DayOfWeek.THURSDAY -> "목"
-        DayOfWeek.FRIDAY -> "금"
-        DayOfWeek.SATURDAY -> "토"
     }
 
     private fun bindRecordToViews(record: RecordResponse) {

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeListFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeListFragment.kt
@@ -18,6 +18,7 @@ import com.example.momolabfe.ui.record.adapter.ExchangeInfoAdapter
 import com.example.momolabfe.ui.record.data.RecordExchangeInfo
 import com.example.momolabfe.ui.record.viewModel.RecordViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
@@ -53,6 +54,12 @@ class RecordExchangeListFragment : Fragment() {
         setupRecycler()
         setupObservers()
 
+        // 전달된 날짜 문자열 꺼내기 (기본값: 오늘 날짜 포맷 or 빈 문자열)
+        val dateText = arguments?.getString("selected_date_text")
+            ?: LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy년 M월 d일"))
+        val dwKorean = arguments?.getString("selected_date_dw")
+            ?: weekdayShortKorean(LocalDate.now().dayOfWeek)
+
         // 넘겨준 이미지 Uri로 OCR 호출
         val imageUri: Uri? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             arguments?.getParcelable("image_uri", Uri::class.java)
@@ -81,6 +88,16 @@ class RecordExchangeListFragment : Fragment() {
         DayWeek.FRI -> "(금)"
         DayWeek.SAT -> "(토)"
         DayWeek.SUN -> "(일)"
+    }
+
+    private fun weekdayShortKorean(dow: DayOfWeek): String = when (dow) {
+        DayOfWeek.SUNDAY -> "일"
+        DayOfWeek.MONDAY -> "월"
+        DayOfWeek.TUESDAY -> "화"
+        DayOfWeek.WEDNESDAY -> "수"
+        DayOfWeek.THURSDAY -> "목"
+        DayOfWeek.FRIDAY -> "금"
+        DayOfWeek.SATURDAY -> "토"
     }
 
     private fun bindRecordToViews(record: RecordResponse) {

--- a/app/src/main/java/com/example/momolabfe/ui/record/SelectRecordDateFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/SelectRecordDateFragment.kt
@@ -13,8 +13,9 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.example.momolabfe.R
-import com.example.momolabfe.data.remote.record.model.DayWeek
 import com.example.momolabfe.databinding.FragmentRecordSelectDateBinding
+import com.example.momolabfe.utils.toDayWeek
+import com.example.momolabfe.utils.weekdayShortKorean
 import com.kizitonwose.calendar.core.CalendarDay
 import com.kizitonwose.calendar.core.CalendarMonth
 import com.kizitonwose.calendar.core.DayPosition
@@ -184,26 +185,6 @@ class SelectRecordDateFragment : Fragment() {
             }
             container.addView(tv)
         }
-    }
-
-    private fun weekdayShortKorean(dow: DayOfWeek): String = when (dow) {
-        DayOfWeek.SUNDAY -> "일"
-        DayOfWeek.MONDAY -> "월"
-        DayOfWeek.TUESDAY -> "화"
-        DayOfWeek.WEDNESDAY -> "수"
-        DayOfWeek.THURSDAY -> "목"
-        DayOfWeek.FRIDAY -> "금"
-        DayOfWeek.SATURDAY -> "토"
-    }
-
-    private fun DayOfWeek.toDayWeek(): DayWeek = when (this) {
-        DayOfWeek.MONDAY -> DayWeek.MON
-        DayOfWeek.TUESDAY -> DayWeek.TUE
-        DayOfWeek.WEDNESDAY -> DayWeek.WED
-        DayOfWeek.THURSDAY -> DayWeek.THU
-        DayOfWeek.FRIDAY -> DayWeek.FRI
-        DayOfWeek.SATURDAY -> DayWeek.SAT
-        DayOfWeek.SUNDAY -> DayWeek.SUN
     }
 
     // 월 범위 요청 함수 (캘린더 조회용)

--- a/app/src/main/java/com/example/momolabfe/ui/record/SelectRecordDateFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/SelectRecordDateFragment.kt
@@ -13,6 +13,7 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.example.momolabfe.R
+import com.example.momolabfe.data.remote.record.model.DayWeek
 import com.example.momolabfe.databinding.FragmentRecordSelectDateBinding
 import com.kizitonwose.calendar.core.CalendarDay
 import com.kizitonwose.calendar.core.CalendarMonth
@@ -148,7 +149,12 @@ class SelectRecordDateFragment : Fragment() {
 
         binding.nextBtn.setOnClickListener {
             val dateText = selectedDate.format(sendFormatter) // 선택한 날짜 값 전달
-            val args = Bundle().apply { putString("selected_date_text", dateText) }
+            val dwKorean = selectedDate.dayOfWeek.toDayWeek().name
+
+            val args = Bundle().apply {
+                putString("selected_date_text", dateText)
+                putString("selected_date_dw", dwKorean)
+            }
             val fragment = RecordExchangeInfoFragment().apply { arguments = args } // 추후에 CommonRecordInfoFragment로 수정 필요
 
             parentFragmentManager.beginTransaction()
@@ -188,6 +194,16 @@ class SelectRecordDateFragment : Fragment() {
         DayOfWeek.THURSDAY -> "목"
         DayOfWeek.FRIDAY -> "금"
         DayOfWeek.SATURDAY -> "토"
+    }
+
+    private fun DayOfWeek.toDayWeek(): DayWeek = when (this) {
+        DayOfWeek.MONDAY -> DayWeek.MON
+        DayOfWeek.TUESDAY -> DayWeek.TUE
+        DayOfWeek.WEDNESDAY -> DayWeek.WED
+        DayOfWeek.THURSDAY -> DayWeek.THU
+        DayOfWeek.FRIDAY -> DayWeek.FRI
+        DayOfWeek.SATURDAY -> DayWeek.SAT
+        DayOfWeek.SUNDAY -> DayWeek.SUN
     }
 
     // 월 범위 요청 함수 (캘린더 조회용)

--- a/app/src/main/java/com/example/momolabfe/utils/DayWeekExtensions.kt
+++ b/app/src/main/java/com/example/momolabfe/utils/DayWeekExtensions.kt
@@ -24,11 +24,11 @@ fun DayOfWeek.toDayWeek(): DayWeek = when (this) {
 }
 
 fun DayWeek.korean(): String = when (this) {
-    DayWeek.MON -> "월"
-    DayWeek.TUE -> "화"
-    DayWeek.WED -> "수"
-    DayWeek.THU -> "목"
-    DayWeek.FRI -> "금"
-    DayWeek.SAT -> "토"
-    DayWeek.SUN -> "일"
+    DayWeek.MON -> "(월)"
+    DayWeek.TUE -> "(화)"
+    DayWeek.WED -> "(수)"
+    DayWeek.THU -> "(목)"
+    DayWeek.FRI -> "(금)"
+    DayWeek.SAT -> "(토)"
+    DayWeek.SUN -> "(일)"
 }

--- a/app/src/main/java/com/example/momolabfe/utils/DayWeekExtensions.kt
+++ b/app/src/main/java/com/example/momolabfe/utils/DayWeekExtensions.kt
@@ -1,0 +1,34 @@
+package com.example.momolabfe.utils
+
+import com.example.momolabfe.data.remote.record.model.DayWeek
+import java.time.DayOfWeek
+
+fun weekdayShortKorean(dow: DayOfWeek): String = when (dow) {
+    DayOfWeek.SUNDAY -> "일"
+    DayOfWeek.MONDAY -> "월"
+    DayOfWeek.TUESDAY -> "화"
+    DayOfWeek.WEDNESDAY -> "수"
+    DayOfWeek.THURSDAY -> "목"
+    DayOfWeek.FRIDAY -> "금"
+    DayOfWeek.SATURDAY -> "토"
+}
+
+fun DayOfWeek.toDayWeek(): DayWeek = when (this) {
+    DayOfWeek.MONDAY    -> DayWeek.MON
+    DayOfWeek.TUESDAY   -> DayWeek.TUE
+    DayOfWeek.WEDNESDAY -> DayWeek.WED
+    DayOfWeek.THURSDAY  -> DayWeek.THU
+    DayOfWeek.FRIDAY    -> DayWeek.FRI
+    DayOfWeek.SATURDAY  -> DayWeek.SAT
+    DayOfWeek.SUNDAY    -> DayWeek.SUN
+}
+
+fun DayWeek.korean(): String = when (this) {
+    DayWeek.MON -> "월"
+    DayWeek.TUE -> "화"
+    DayWeek.WED -> "수"
+    DayWeek.THU -> "목"
+    DayWeek.FRI -> "금"
+    DayWeek.SAT -> "토"
+    DayWeek.SUN -> "일"
+}

--- a/app/src/main/res/layout/fragment_record_exchange_info.xml
+++ b/app/src/main/res/layout/fragment_record_exchange_info.xml
@@ -36,6 +36,20 @@
         app:layout_constraintTop_toTopOf="@id/title_tv"/>
 
     <TextView
+        android:id="@+id/dw_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="3dp"
+        tools:text="(목)"
+        android:textColor="@color/text_primary"
+        android:fontFamily="@font/noto_sans_kr_regular"
+        android:textSize="23sp"
+        android:textStyle="bold"
+        android:includeFontPadding="false"
+        app:layout_constraintStart_toEndOf="@id/date_tv"
+        app:layout_constraintTop_toTopOf="@id/date_tv"/>
+
+    <TextView
         android:id="@+id/exchange_no_tv"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_record_exchange_list.xml
+++ b/app/src/main/res/layout/fragment_record_exchange_list.xml
@@ -399,10 +399,22 @@
                         app:layout_constraintTop_toTopOf="@id/total_uf_tv" />
 
                     <TextView
+                        android:id="@+id/total_uf_info_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="*제수량 합계는 모든 회차별 제수량을 더한 결과입니다."
+                        android:textSize="13sp"
+                        android:fontFamily="@font/noto_sans_kr_regular"
+                        android:textColor="@color/main_2"
+                        android:textStyle="bold"
+                        app:layout_constraintStart_toStartOf="@id/total_uf_tv"
+                        app:layout_constraintTop_toBottomOf="@id/total_uf_tv"/>
+
+                    <TextView
                         android:id="@+id/notes_tv"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="10dp"
+                        android:layout_marginTop="5dp"
                         android:fontFamily="@font/noto_sans_kr_regular"
                         android:includeFontPadding="false"
                         android:text="비고"
@@ -410,7 +422,7 @@
                         android:textSize="16sp"
                         android:textStyle="bold"
                         app:layout_constraintStart_toStartOf="@id/total_uf_tv"
-                        app:layout_constraintTop_toBottomOf="@id/total_uf_tv" />
+                        app:layout_constraintTop_toBottomOf="@id/total_uf_info_tv" />
 
                     <EditText
                         android:id="@+id/notes_et"

--- a/app/src/main/res/layout/fragment_record_exchange_list.xml
+++ b/app/src/main/res/layout/fragment_record_exchange_list.xml
@@ -25,7 +25,7 @@
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/noto_sans_kr_regular"
                 android:includeFontPadding="false"
-                android:text="교환일시 모아보기"
+                android:text="회차정보 모아보기"
                 android:textColor="@color/text_primary"
                 android:textSize="23sp"
                 android:textStyle="bold"


### PR DESCRIPTION
## 📝 작업 내용
수기 작성 시 캘린더에서 날짜를 선택하면, 요일값까지 전달하여 상단에 노출하는 구조
요일은 (월) 이런식으로 표시
ex: 2025년 10월 31일 (금)

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음