### PR TITLE
[Feat/#37] 회차별 정보 수기 작성 api 연동

### DIFF
--- a/app/src/main/java/com/example/momolabfe/data/remote/record/model/RecordRequest.kt
+++ b/app/src/main/java/com/example/momolabfe/data/remote/record/model/RecordRequest.kt
@@ -2,6 +2,7 @@ package com.example.momolabfe.data.remote.record.model
 
 import com.google.gson.annotations.SerializedName
 import java.time.LocalDate
+import java.time.LocalTime
 
 
 data class RecordCreateRequest (
@@ -15,4 +16,13 @@ data class RecordCreateRequest (
     @SerializedName("turbidity") val turbidity: Turbidity,
     @SerializedName("notes") val notes: String? = null,
     @SerializedName("total_uf") val totalUf: Int,
+)
+
+data class RecordExchangeCreateRequest (
+    @SerializedName("exchange_time") val exchangeTime: LocalTime,
+    @SerializedName("drain_volume") val drainVolume: Int,
+    @SerializedName("fill_volume") val fillVolume: Int,
+    @SerializedName("fill_concentration") val fillConcentration: Float,
+    @SerializedName("uf") val uf: Int
+
 )

--- a/app/src/main/java/com/example/momolabfe/data/remote/record/model/RecordResponse.kt
+++ b/app/src/main/java/com/example/momolabfe/data/remote/record/model/RecordResponse.kt
@@ -28,3 +28,7 @@ data class RecordExchangeOcrResponse (
     @SerializedName("fill_concentration") val fillConcentration: Double,
     @SerializedName("uf") val uf: Int
 )
+
+data class RecordIdResponse (
+    @SerializedName("id") val id: Long
+)

--- a/app/src/main/java/com/example/momolabfe/data/remote/record/model/RecordResponse.kt
+++ b/app/src/main/java/com/example/momolabfe/data/remote/record/model/RecordResponse.kt
@@ -25,7 +25,7 @@ data class RecordExchangeOcrResponse (
     @SerializedName("exchange_time") val exchangeTime: LocalTime,
     @SerializedName("drain_volume") val drainVolume: Int,
     @SerializedName("fill_volume") val fillVolume: Int,
-    @SerializedName("fill_concentration") val fillConcentration: Double,
+    @SerializedName("fill_concentration") val fillConcentration: Float,
     @SerializedName("uf") val uf: Int
 )
 

--- a/app/src/main/java/com/example/momolabfe/data/remote/record/repository/RecordRepository.kt
+++ b/app/src/main/java/com/example/momolabfe/data/remote/record/repository/RecordRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
 import com.example.momolabfe.data.remote.record.model.RecordCreateRequest
+import com.example.momolabfe.data.remote.record.model.RecordExchangeCreateRequest
 import com.example.momolabfe.data.remote.record.model.RecordOcrResponse
 import com.example.momolabfe.data.remote.record.service.RecordService
 import com.example.momolabfe.utils.ApiException
@@ -24,9 +25,18 @@ class RecordRepository @Inject constructor (
 ) {
     private val ALLOWED_TYPES = setOf("image/jpeg", "image/png")
 
-    // 수기 작성 - 공통 기록 생성
+    // 수기 작성 - 공통 정보 생성
     suspend fun recordCommonByWriting(request: RecordCreateRequest): Result<Unit> = runCatching {
         val response = recordService.recordCommonByWriting(request)
+        if (!response.isSuccessful) {
+            throw ApiException(response.code(), "HTTP ${response.code()}")
+        }
+        Unit
+    }
+
+    // 수기 작성 - 회차별 정보 생성
+    suspend fun recordExchangeByWriting(recId: Long, request: RecordExchangeCreateRequest): Result<Unit> = runCatching {
+        val response = recordService.recordExchangeByWriting(recId, request)
         if (!response.isSuccessful) {
             throw ApiException(response.code(), "HTTP ${response.code()}")
         }

--- a/app/src/main/java/com/example/momolabfe/data/remote/record/repository/RecordRepository.kt
+++ b/app/src/main/java/com/example/momolabfe/data/remote/record/repository/RecordRepository.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.provider.OpenableColumns
 import com.example.momolabfe.data.remote.record.model.RecordCreateRequest
 import com.example.momolabfe.data.remote.record.model.RecordExchangeCreateRequest
+import com.example.momolabfe.data.remote.record.model.RecordIdResponse
 import com.example.momolabfe.data.remote.record.model.RecordOcrResponse
 import com.example.momolabfe.data.remote.record.service.RecordService
 import com.example.momolabfe.utils.ApiException
@@ -26,12 +27,13 @@ class RecordRepository @Inject constructor (
     private val ALLOWED_TYPES = setOf("image/jpeg", "image/png")
 
     // 수기 작성 - 공통 정보 생성
-    suspend fun recordCommonByWriting(request: RecordCreateRequest): Result<Unit> = runCatching {
+    suspend fun recordCommonByWriting(request: RecordCreateRequest): Result<Long> = runCatching {
         val response = recordService.recordCommonByWriting(request)
         if (!response.isSuccessful) {
             throw ApiException(response.code(), "HTTP ${response.code()}")
         }
-        Unit
+        val body = response.body() ?: throw ApiException(500, "빈 응답 본문")
+        body.id
     }
 
     // 수기 작성 - 회차별 정보 생성

--- a/app/src/main/java/com/example/momolabfe/data/remote/record/service/RecordService.kt
+++ b/app/src/main/java/com/example/momolabfe/data/remote/record/service/RecordService.kt
@@ -1,6 +1,7 @@
 package com.example.momolabfe.data.remote.record.service
 
 import com.example.momolabfe.data.remote.record.model.RecordCreateRequest
+import com.example.momolabfe.data.remote.record.model.RecordExchangeCreateRequest
 import com.example.momolabfe.data.remote.record.model.RecordOcrResponse
 import okhttp3.MultipartBody
 import retrofit2.Response
@@ -8,11 +9,15 @@ import retrofit2.http.Body
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
+import retrofit2.http.Path
 
 interface RecordService {
 
     @POST("/api/v1/records")
     suspend fun recordCommonByWriting(@Body request: RecordCreateRequest): Response<Unit>
+
+    @POST("/api/v1/records/{rec_id}/exchanges")
+    suspend fun recordExchangeByWriting(@Path("rec_id") recid: Long, @Body request: RecordExchangeCreateRequest): Response<Unit>
 
     @Multipart
     @POST("/api/v1/ocr")

--- a/app/src/main/java/com/example/momolabfe/data/remote/record/service/RecordService.kt
+++ b/app/src/main/java/com/example/momolabfe/data/remote/record/service/RecordService.kt
@@ -2,6 +2,7 @@ package com.example.momolabfe.data.remote.record.service
 
 import com.example.momolabfe.data.remote.record.model.RecordCreateRequest
 import com.example.momolabfe.data.remote.record.model.RecordExchangeCreateRequest
+import com.example.momolabfe.data.remote.record.model.RecordIdResponse
 import com.example.momolabfe.data.remote.record.model.RecordOcrResponse
 import okhttp3.MultipartBody
 import retrofit2.Response
@@ -14,10 +15,10 @@ import retrofit2.http.Path
 interface RecordService {
 
     @POST("/api/v1/records")
-    suspend fun recordCommonByWriting(@Body request: RecordCreateRequest): Response<Unit>
+    suspend fun recordCommonByWriting(@Body request: RecordCreateRequest): Response<RecordIdResponse>
 
     @POST("/api/v1/records/{rec_id}/exchanges")
-    suspend fun recordExchangeByWriting(@Path("rec_id") recid: Long, @Body request: RecordExchangeCreateRequest): Response<Unit>
+    suspend fun recordExchangeByWriting(@Path("rec_id") recId: Long, @Body request: RecordExchangeCreateRequest): Response<Unit>
 
     @Multipart
     @POST("/api/v1/ocr")

--- a/app/src/main/java/com/example/momolabfe/ui/record/CommonRecordInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/CommonRecordInfoFragment.kt
@@ -224,7 +224,7 @@ class CommonRecordInfoFragment : Fragment() {
         // 성공 이벤트는 Flow 수집으로 1회성 처리
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.recordSuccess.collect {
+                viewModel.recordCreated.collect { recId ->
                     Log.d("RECORD_COMMON_BY_WRITING_FRAGMENT", "공통 정보 작성이 정상적으로 완료되었습니다.")
 
                     val dateStr = binding.dateTv.text?.toString()?.trim().orEmpty()
@@ -233,6 +233,7 @@ class CommonRecordInfoFragment : Fragment() {
                     val recordDw = recordDate.dayOfWeek.toDayWeek()
 
                     val args = Bundle().apply {
+                        putLong("rec_id", recId)
                         putString("record_date", recordDate.toString())
                         putString("record_dw", recordDw.name)
                         putString("record_date_text", dateStr)

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeInfoFragment.kt
@@ -1,24 +1,53 @@
 package com.example.momolabfe.ui.record
 
+import android.graphics.Color
 import android.os.Bundle
+import android.text.Editable
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.example.momolabfe.R
 import com.example.momolabfe.data.remote.record.model.DayWeek
+import com.example.momolabfe.data.remote.record.model.RecordCreateRequest
+import com.example.momolabfe.data.remote.record.model.RecordExchangeCreateRequest
+import com.example.momolabfe.data.remote.record.model.Turbidity
 import com.example.momolabfe.databinding.FragmentRecordExchangeInfoBinding
+import com.example.momolabfe.ui.record.viewModel.RecordViewModel
 import com.example.momolabfe.utils.korean
 import com.example.momolabfe.utils.toDayWeek
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import kotlinx.coroutines.launch
+import java.math.BigDecimal
 import java.time.DayOfWeek
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.util.Locale
 
 class RecordExchangeInfoFragment : Fragment() {
 
     private var _binding: FragmentRecordExchangeInfoBinding? = null
     private val binding get() = _binding!!
+
+    private var recId: Long = -1
+
+    private val viewModel: RecordViewModel by activityViewModels()
+
+    private val fmtHH_MM = DateTimeFormatter.ofPattern("HH:mm", Locale.KOREA)
+    private val fmtHH_MM_SS = DateTimeFormatter.ofPattern("HH:mm:ss", Locale.KOREA)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        recId = arguments?.getLong("rec_id") ?: -1L
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -41,17 +70,138 @@ class RecordExchangeInfoFragment : Fragment() {
         binding.dateTv.text = dateText
         binding.dwTv.text = dwKorean
 
-        binding.searchBtn.setOnClickListener {
-            val args = Bundle().apply {
-                putString("selected_date_text", dateText)
-                putString("selected_date_dw", dwKorean)
-            }
-            val fragment = RecordExchangeListFragment().apply { arguments = args }
+        setupUI()
+        setupObservers()
+    }
 
-            parentFragmentManager.beginTransaction()
-                .replace(R.id.main_frm, fragment)
-                .addToBackStack(null)
-                .commit()
+    private fun setupUI() {
+
+        // 텍스트 변경 감지 → 버튼 상태 갱신
+        val watcher: (Editable?) -> Unit = { updateNextButtonState() }
+        binding.exchangeTimeEt.addTextChangedListener(afterTextChanged = watcher)
+        binding.drainVolumeEt.addTextChangedListener(afterTextChanged = watcher)
+        binding.fillVolumeEt.addTextChangedListener(afterTextChanged = watcher)
+        binding.fillConcentrationEt.addTextChangedListener(afterTextChanged = watcher)
+        binding.ufDataEt.addTextChangedListener(afterTextChanged = watcher)
+
+        updateNextButtonState()
+
+        binding.searchBtn.setOnClickListener {
+            if (recId != -1L) {
+                val request = createRecordExchangeRequest()
+                viewModel.recordExchangeByWriting(recId, request)
+            }
         }
+    }
+
+    private fun updateNextButtonState() {
+        val exchangeTime = binding.exchangeTimeEt.text?.toString()?.trim().orEmpty()
+        val drainVolume = binding.drainVolumeEt.text?.toString()?.trim().orEmpty()
+        val fillVolume = binding.fillVolumeEt.text?.toString()?.trim().orEmpty()
+        val fillConcentration = binding.fillConcentrationEt.text?.toString()?.trim().orEmpty()
+        val uf = binding.ufDataEt.text?.toString()?.trim().orEmpty()
+
+        val enabled = isValidExchangeTime(exchangeTime) &&
+                isValidDrainVolume(drainVolume) &&
+                isValidFillVolume(fillVolume) &&
+                isValidFillConcentration(fillConcentration) &&
+                isValidUf(uf)
+
+        binding.searchBtn.isEnabled = enabled
+        binding.searchBtn.setBackgroundColor(
+            if (enabled) requireContext().getColor(R.color.text_primary) else Color.parseColor("#F6F6F6")
+        )
+        binding.searchBtn.setTextColor(
+            if (enabled) requireContext().getColor(R.color.white) else requireContext().getColor(R.color.main_2)
+        )
+    }
+
+    // 시간 파싱
+    private fun parseExchangeTime(raw: String): LocalTime? {
+        val s = raw.trim()
+        if (s.isEmpty()) return null
+        return try {
+            LocalTime.parse(s, fmtHH_MM) // 우선 HH:mm 시도
+        } catch (_: DateTimeParseException) {
+            try { LocalTime.parse(s, fmtHH_MM_SS) } // 안되면 HH:mm:ss
+            catch (_: DateTimeParseException) { null }
+        }
+    }
+
+    // 파싱 성공이면 유효
+    fun isValidExchangeTime(s: String): Boolean = parseExchangeTime(s) != null
+
+    // LocalTime → "HH:mm:ss"
+    fun toDbTimeString(t: LocalTime): String = t.format(fmtHH_MM_SS)
+
+    // LocalTime → "HH:mm"
+    fun toDisplayTimeString(t: LocalTime): String = t.format(fmtHH_MM)
+
+    // 배액량: 0 ~ 6000
+    private fun isValidDrainVolume(s: String): Boolean =
+        s.toIntOrNull()?.let { it in 0..6000 } == true
+
+    // 주입액 중량: 0 ~ 6000
+    private fun isValidFillVolume(s: String): Boolean =
+        s.toIntOrNull()?.let { it in 0..6000 } == true
+
+    // 주입액 농도: 0 ~ 100
+    private fun isValidFillConcentration(s: String): Boolean {
+        val bd = s.toBigDecimalOrNull() ?: return false
+        return bd >= BigDecimal("0") && bd <= BigDecimal("100.0")
+    }
+
+    // 제수량: -500 ~ 500
+    private fun isValidUf(s: String): Boolean =
+        s.toIntOrNull()?.let { it in -500..500 } == true
+
+
+    private fun createRecordExchangeRequest(): RecordExchangeCreateRequest {
+        val exchangeTimeInput = binding.exchangeTimeEt.text?.toString()?.trim().orEmpty()
+        val time = parseExchangeTime(exchangeTimeInput)
+            ?: error("교환시각 형식 오류 (예: 09:00 또는 09:00:00)")
+
+        val drainVolume = binding.drainVolumeEt.text?.toString()?.trim()?.toIntOrNull()
+            ?: error("배액량 파싱 에러")
+        val fillVolume = binding.fillVolumeEt.text?.toString()?.trim()?.toIntOrNull()
+            ?: error("주입액 중량 파싱 에러")
+        val fillConcentration = binding.fillConcentrationEt.text?.toString()?.trim()?.toFloatOrNull()
+            ?: error("주입액 농도 파싱 에러")
+        val uf = binding.ufDataEt.text?.toString()?.trim()?.toIntOrNull()
+            ?: error("제수량 파싱 에러")
+
+        return RecordExchangeCreateRequest(
+            exchangeTime = time,
+            drainVolume = drainVolume,
+            fillVolume = fillVolume,
+            fillConcentration = fillConcentration,
+            uf = uf
+        )
+    }
+
+    private fun setupObservers() {
+
+        // 성공 이벤트는 Flow 수집으로 1회성 처리
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.recordSuccess.collect {
+                    Log.d("RECORD_EXCHANGE_BY_WRITING_FRAGMENT", "회차별 정보 작성이 정상적으로 완료되었습니다.")
+
+                    parentFragmentManager.beginTransaction()
+                        .replace(R.id.main_frm, RecordExchangeListFragment())
+                        .addToBackStack(null)
+                        .commit()
+                }
+            }
+        }
+
+        viewModel.errorMessage.observe(viewLifecycleOwner) { errorMsg ->
+            Log.e("RECORD_EXCHANGE_BY_WRITING_FRAGMENT", errorMsg.toString())
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeInfoFragment.kt
@@ -14,19 +14,12 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.example.momolabfe.R
-import com.example.momolabfe.data.remote.record.model.DayWeek
-import com.example.momolabfe.data.remote.record.model.RecordCreateRequest
 import com.example.momolabfe.data.remote.record.model.RecordExchangeCreateRequest
-import com.example.momolabfe.data.remote.record.model.Turbidity
 import com.example.momolabfe.databinding.FragmentRecordExchangeInfoBinding
 import com.example.momolabfe.ui.record.viewModel.RecordViewModel
-import com.example.momolabfe.utils.korean
-import com.example.momolabfe.utils.toDayWeek
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
-import java.time.DayOfWeek
-import java.time.LocalDate
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
@@ -37,7 +30,7 @@ class RecordExchangeInfoFragment : Fragment() {
     private var _binding: FragmentRecordExchangeInfoBinding? = null
     private val binding get() = _binding!!
 
-    private var recId: Long = -1
+    private var recId: Long = -1L
 
     private val viewModel: RecordViewModel by activityViewModels()
 
@@ -109,10 +102,10 @@ class RecordExchangeInfoFragment : Fragment() {
 
         binding.searchBtn.isEnabled = enabled
         binding.searchBtn.setBackgroundColor(
-            if (enabled) requireContext().getColor(R.color.text_primary) else Color.parseColor("#F6F6F6")
+            if (enabled) requireContext().getColor(R.color.main_2) else Color.parseColor("#F6F6F6")
         )
         binding.searchBtn.setTextColor(
-            if (enabled) requireContext().getColor(R.color.white) else requireContext().getColor(R.color.main_2)
+            if (enabled) requireContext().getColor(R.color.white) else requireContext().getColor(R.color.text_primary)
         )
     }
 

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeInfoFragment.kt
@@ -122,13 +122,7 @@ class RecordExchangeInfoFragment : Fragment() {
     }
 
     // 파싱 성공이면 유효
-    fun isValidExchangeTime(s: String): Boolean = parseExchangeTime(s) != null
-
-    // LocalTime → "HH:mm:ss"
-    fun toDbTimeString(t: LocalTime): String = t.format(fmtHH_MM_SS)
-
-    // LocalTime → "HH:mm"
-    fun toDisplayTimeString(t: LocalTime): String = t.format(fmtHH_MM)
+    private fun isValidExchangeTime(s: String): Boolean = parseExchangeTime(s) != null
 
     // 배액량: 0 ~ 6000
     private fun isValidDrainVolume(s: String): Boolean =

--- a/app/src/main/java/com/example/momolabfe/ui/record/SelectRecordDateFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/SelectRecordDateFragment.kt
@@ -160,7 +160,7 @@ class SelectRecordDateFragment : Fragment() {
                 putString("selected_date_text", dateText)
                 putString("selected_date_dw", dwKorean)
             }
-            val fragment = RecordExchangeInfoFragment().apply { arguments = args } // 추후에 CommonRecordInfoFragment로 수정 필요
+            val fragment = CommonRecordInfoFragment().apply { arguments = args } // 추후에 CommonRecordInfoFragment로 수정 필요
 
             parentFragmentManager.beginTransaction()
                 .replace(R.id.main_frm, fragment)

--- a/app/src/main/java/com/example/momolabfe/ui/record/SelectRecordDateFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/SelectRecordDateFragment.kt
@@ -160,7 +160,7 @@ class SelectRecordDateFragment : Fragment() {
                 putString("selected_date_text", dateText)
                 putString("selected_date_dw", dwKorean)
             }
-            val fragment = CommonRecordInfoFragment().apply { arguments = args } // 추후에 CommonRecordInfoFragment로 수정 필요
+            val fragment = RecordExchangeInfoFragment().apply { arguments = args } // 추후에 CommonRecordInfoFragment로 수정 필요
 
             parentFragmentManager.beginTransaction()
                 .replace(R.id.main_frm, fragment)

--- a/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.momolabfe.data.remote.record.model.RecordCreateRequest
+import com.example.momolabfe.data.remote.record.model.RecordExchangeCreateRequest
 import com.example.momolabfe.data.remote.record.model.RecordOcrResponse
 import com.example.momolabfe.data.remote.record.repository.RecordRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -40,6 +41,18 @@ class RecordViewModel @Inject constructor(
                 _recordSuccess.tryEmit(Unit)
             }.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "공통 정보 저장에 실패했습니다."
+            }
+        }
+    }
+
+    // 수기 작성 - 회차별 정보
+    fun recordExchangeByWriting(recId: Long, request: RecordExchangeCreateRequest) {
+        viewModelScope.launch {
+            val result = recordRepository.recordExchangeByWriting(recId, request)
+            result.onSuccess {
+                _recordSuccess.tryEmit(Unit)
+            }.onFailure { e ->
+                _errorMessage.value = e.localizedMessage ?: "회차별 정보 저장에 실패했습니다."
             }
         }
     }

--- a/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
@@ -33,12 +33,15 @@ class RecordViewModel @Inject constructor(
     private val _ocrRecordResult = MutableLiveData<RecordOcrResponse?>()
     val ocrRecordResult: LiveData<RecordOcrResponse?> get() = _ocrRecordResult
 
+    private val _recordCreated = MutableSharedFlow<Long>(extraBufferCapacity = 1)
+    val recordCreated: SharedFlow<Long> = _recordCreated
+
     // 수기 작성 - 공통 정보
     fun recordCommonByWriting(request: RecordCreateRequest) {
         viewModelScope.launch {
             val result = recordRepository.recordCommonByWriting(request)
-            result.onSuccess {
-                _recordSuccess.tryEmit(Unit)
+            result.onSuccess { id ->
+                _recordCreated.emit(id)
             }.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "공통 정보 저장에 실패했습니다."
             }

--- a/app/src/main/res/layout/fragment_record_exchange_info.xml
+++ b/app/src/main/res/layout/fragment_record_exchange_info.xml
@@ -135,7 +135,7 @@
                 android:fontFamily="@font/noto_sans_kr_regular"
                 android:includeFontPadding="false"
                 android:textColor="@color/text_primary"
-                android:inputType="datetime"
+                android:inputType="text"
                 android:textSize="16sp" />
 
         </LinearLayout>
@@ -344,15 +344,16 @@
         android:text="회차별 기록 조회하기"
         android:textSize="15sp"
         android:fontFamily="@font/noto_sans_kr_regular"
-        android:textColor="@color/white"
+        android:textColor="@color/text_primary"
         app:cornerRadius="12dp"
-        android:backgroundTint="@color/main_2"
+        android:backgroundTint="#F6F6F6"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         android:layout_marginStart="19dp"
         android:layout_marginEnd="19dp"
-        android:layout_marginBottom="50dp"/>
+        android:layout_marginBottom="50dp"
+        android:enabled="false"/>
 
 
 


### PR DESCRIPTION
## 📝 작업 내용
회차별 정보 수기 작성 api 연동하였습니다.
공통 정보 입력 화면에서 기록 아이디를 반환하여 회차별 정보 입력 화면에 데이터를 전달하고, 아이디 값을 받아와서 회차별 정보 수기 작성 api를 호출합니다.

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회차별 정보 기록(교환 정보 등록) 기능 추가
  * 생성된 기록 ID를 반환·전달하여 후속 흐름에 활용

* **UI 개선**
  * 교환 시간 입력 필드 형식 및 편의 개선
  * 교환 입력값(시간, 배액량, 주입량, 주입농도, UF) 실시간 검증 및 버튼 활성화 제어

* **버그 수정**
  * 일부 수치 필드 타입 일관성 개선 (정밀도 조정)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->