### PR TITLE
[Refactor/#38] 회차시각 타임피커 적용

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeInfoFragment.kt
@@ -86,7 +86,7 @@ class RecordExchangeInfoFragment : Fragment() {
         // Picker 초기화
         ampmPicker.minValue = 0
         ampmPicker.maxValue = 1
-        ampmPicker.displayedValues = arrayOf("AM", "PM")
+        ampmPicker.displayedValues = arrayOf("오전", "오후")
 
         hourPicker.minValue = 1
         hourPicker.maxValue = 12
@@ -119,10 +119,16 @@ class RecordExchangeInfoFragment : Fragment() {
             if (!isAm) hour += 12
             if (hour == 0) hour = 0 // 12AM → 0시로
 
-            val minute = minuteValues[minutePicker.value]
+            val minuteStr = minuteValues[minutePicker.value]
+            val minuteInt = minuteStr.toInt()
 
-            // "HH:mm"으로 표기 (내부 검증/전송 로직과 호환)
-            targetView.text = String.format("%02d:%02d", hour, minute)
+            val selected = LocalTime.of(hour, minuteInt)
+
+            // 화면 표시는 HH:mm
+            targetView.text = selected.format(fmtHH_MM)
+            // 내부 저장은 LocalTime (서버 전송 시 HH:mm:ss로 쉽게 변환)
+            targetView.tag  = selected
+
             updateNextButtonState()
 
             dialog.dismiss()

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordExchangeInfoFragment.kt
@@ -7,6 +7,8 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.NumberPicker
+import android.widget.TextView
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -18,6 +20,7 @@ import com.example.momolabfe.data.remote.record.model.RecordExchangeCreateReques
 import com.example.momolabfe.databinding.FragmentRecordExchangeInfoBinding
 import com.example.momolabfe.ui.record.viewModel.RecordViewModel
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
 import java.time.LocalTime
@@ -63,15 +66,75 @@ class RecordExchangeInfoFragment : Fragment() {
         binding.dateTv.text = dateText
         binding.dwTv.text = dwKorean
 
+        binding.exchangeTimeDataTv.setOnClickListener {
+            showCustomTimePicker(binding.exchangeTimeDataTv)
+        }
+
         setupUI()
         setupObservers()
+    }
+
+    private fun showCustomTimePicker(targetView: TextView) {
+        val dialogView = layoutInflater.inflate(R.layout.bottom_sheet_time_picker, null, false)
+
+        val ampmPicker = dialogView.findViewById<NumberPicker>(R.id.ampm_picker)
+        val hourPicker = dialogView.findViewById<NumberPicker>(R.id.hour_picker)
+        val minutePicker = dialogView.findViewById<NumberPicker>(R.id.minute_picker)
+
+        val minuteValues = arrayOf("00", "10", "20", "30", "40", "50")
+
+        // Picker 초기화
+        ampmPicker.minValue = 0
+        ampmPicker.maxValue = 1
+        ampmPicker.displayedValues = arrayOf("AM", "PM")
+
+        hourPicker.minValue = 1
+        hourPicker.maxValue = 12
+        hourPicker.wrapSelectorWheel = true
+
+        minutePicker.minValue = 0
+        minutePicker.maxValue = minuteValues.size - 1
+        minutePicker.displayedValues = minuteValues
+        minutePicker.wrapSelectorWheel = true
+
+        val dialog = BottomSheetDialog(requireContext())
+        dialog.setContentView(dialogView)
+
+        // 배경 적용
+        dialog.setOnShowListener { dialogInterface ->
+            val bottomSheet = (dialogInterface as BottomSheetDialog)
+                .findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
+            bottomSheet?.setBackgroundResource(R.drawable.calendar_background)
+        }
+
+        // 취소 버튼
+        dialogView.findViewById<TextView>(R.id.cancel_btn).setOnClickListener {
+            dialog.dismiss()
+        }
+
+        // 확인 버튼
+        dialogView.findViewById<TextView>(R.id.confirm_btn).setOnClickListener {
+            val isAm = ampmPicker.value == 0
+            var hour = hourPicker.value % 12
+            if (!isAm) hour += 12
+            if (hour == 0) hour = 0 // 12AM → 0시로
+
+            val minute = minuteValues[minutePicker.value]
+
+            // "HH:mm"으로 표기 (내부 검증/전송 로직과 호환)
+            targetView.text = String.format("%02d:%02d", hour, minute)
+            updateNextButtonState()
+
+            dialog.dismiss()
+        }
+
+        dialog.show()
     }
 
     private fun setupUI() {
 
         // 텍스트 변경 감지 → 버튼 상태 갱신
         val watcher: (Editable?) -> Unit = { updateNextButtonState() }
-        binding.exchangeTimeEt.addTextChangedListener(afterTextChanged = watcher)
         binding.drainVolumeEt.addTextChangedListener(afterTextChanged = watcher)
         binding.fillVolumeEt.addTextChangedListener(afterTextChanged = watcher)
         binding.fillConcentrationEt.addTextChangedListener(afterTextChanged = watcher)
@@ -88,7 +151,7 @@ class RecordExchangeInfoFragment : Fragment() {
     }
 
     private fun updateNextButtonState() {
-        val exchangeTime = binding.exchangeTimeEt.text?.toString()?.trim().orEmpty()
+        val exchangeTime = binding.exchangeTimeDataTv.text?.toString()?.trim().orEmpty()
         val drainVolume = binding.drainVolumeEt.text?.toString()?.trim().orEmpty()
         val fillVolume = binding.fillVolumeEt.text?.toString()?.trim().orEmpty()
         val fillConcentration = binding.fillConcentrationEt.text?.toString()?.trim().orEmpty()
@@ -144,7 +207,7 @@ class RecordExchangeInfoFragment : Fragment() {
 
 
     private fun createRecordExchangeRequest(): RecordExchangeCreateRequest {
-        val exchangeTimeInput = binding.exchangeTimeEt.text?.toString()?.trim().orEmpty()
+        val exchangeTimeInput = binding.exchangeTimeDataTv.text?.toString()?.trim().orEmpty()
         val time = parseExchangeTime(exchangeTimeInput)
             ?: error("교환시각 형식 오류 (예: 09:00 또는 09:00:00)")
 

--- a/app/src/main/java/com/example/momolabfe/ui/record/SelectRecordDateFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/SelectRecordDateFragment.kt
@@ -160,7 +160,7 @@ class SelectRecordDateFragment : Fragment() {
                 putString("selected_date_text", dateText)
                 putString("selected_date_dw", dwKorean)
             }
-            val fragment = RecordExchangeInfoFragment().apply { arguments = args } // 추후에 CommonRecordInfoFragment로 수정 필요
+            val fragment = CommonRecordInfoFragment().apply { arguments = args } // 추후에 CommonRecordInfoFragment로 수정 필요
 
             parentFragmentManager.beginTransaction()
                 .replace(R.id.main_frm, fragment)

--- a/app/src/main/java/com/example/momolabfe/ui/record/SelectRecordDateFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/SelectRecordDateFragment.kt
@@ -160,7 +160,7 @@ class SelectRecordDateFragment : Fragment() {
                 putString("selected_date_text", dateText)
                 putString("selected_date_dw", dwKorean)
             }
-            val fragment = CommonRecordInfoFragment().apply { arguments = args } // 추후에 CommonRecordInfoFragment로 수정 필요
+            val fragment = RecordExchangeInfoFragment().apply { arguments = args } // 추후에 CommonRecordInfoFragment로 수정 필요
 
             parentFragmentManager.beginTransaction()
                 .replace(R.id.main_frm, fragment)

--- a/app/src/main/res/layout/bottom_sheet_time_picker.xml
+++ b/app/src/main/res/layout/bottom_sheet_time_picker.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:id="@+id/pickers_row"
+        android:orientation="horizontal"
+        android:gravity="center"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <NumberPicker
+            android:id="@+id/ampm_picker"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <NumberPicker
+            android:id="@+id/hour_picker"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"/>
+
+        <NumberPicker
+            android:id="@+id/minute_picker"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+    </LinearLayout>
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:gravity="end"
+        android:layout_marginTop="16dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/cancel_btn"
+            android:text="취소"
+            android:padding="12dp"
+            android:textColor="@color/text_primary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <TextView
+            android:id="@+id/confirm_btn"
+            android:text="확인"
+            android:padding="12dp"
+            android:textStyle="bold"
+            android:layout_marginStart="8dp"
+            android:textColor="@color/text_primary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_record_exchange_info.xml
+++ b/app/src/main/res/layout/fragment_record_exchange_info.xml
@@ -113,7 +113,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
         android:layout_marginEnd="50dp"
-        android:backgroundTint="@color/edit_card"
+        android:backgroundTint="@color/main_2"
         app:cardCornerRadius="8dp"
         app:cardElevation="0dp"
         app:layout_constraintEnd_toEndOf="parent"
@@ -135,7 +135,7 @@
                 android:fontFamily="@font/noto_sans_kr_regular"
                 android:text="선택"
                 android:includeFontPadding="false"
-                android:textColor="@color/main_2"
+                android:textColor="@color/white"
                 android:textSize="16sp" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_record_exchange_info.xml
+++ b/app/src/main/res/layout/fragment_record_exchange_info.xml
@@ -113,7 +113,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
         android:layout_marginEnd="50dp"
-        android:backgroundTint="@color/main_2"
+        android:backgroundTint="@color/edit_card"
         app:cardCornerRadius="8dp"
         app:cardElevation="0dp"
         app:layout_constraintEnd_toEndOf="parent"
@@ -134,8 +134,10 @@
                 android:background="@color/transparent"
                 android:fontFamily="@font/noto_sans_kr_regular"
                 android:text="선택"
+                android:clickable="true"
+                android:focusable="true"
                 android:includeFontPadding="false"
-                android:textColor="@color/white"
+                android:textColor="@color/main_2"
                 android:textSize="16sp" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_record_exchange_info.xml
+++ b/app/src/main/res/layout/fragment_record_exchange_info.xml
@@ -125,17 +125,17 @@
             android:orientation="horizontal"
             android:padding="7dp">
 
-            <EditText
-                android:id="@+id/exchange_time_et"
+            <TextView
+                android:id="@+id/exchange_time_data_tv"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="20dp"
                 android:layout_weight="1"
                 android:background="@color/transparent"
                 android:fontFamily="@font/noto_sans_kr_regular"
+                android:text="선택"
                 android:includeFontPadding="false"
-                android:textColor="@color/text_primary"
-                android:inputType="text"
+                android:textColor="@color/main_2"
                 android:textSize="16sp" />
 
         </LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -39,4 +39,10 @@
         <item name="cornerSizeBottomLeft">0dp</item>
         <item name="cornerSizeBottomRight">0dp</item>
     </style>
+
+    <style name="CustomNumberPicker">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">155dp</item>
+        <item name="android:layout_gravity">center</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -9,4 +9,9 @@
     </style>
 
     <style name="Theme.MOMOLABFE" parent="Base.Theme.MOMOLABFE" />
+
+    <style name="TimePickerTheme" parent="Theme.AppCompat.Light.Dialog">
+        <item name="android:textColorPrimary">@color/text_primary</item>
+        <item name="android:colorForeground">@color/transparent</item>
+    </style>
 </resources>


### PR DESCRIPTION
## 📝 작업 내용
회차시각에 타임피커를 적용하였으며, "선택" 클릭 시 타임피커 바텀시트가 올라옵니다.
오전/오후 시/분 을 선택하면 기록 작성 시 시간 값이 데이터로 전달됩니다.
api 동시성 처리 관련해서는 추후에 이슈를 파서 진행할 예정입니다.

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
- 처음 진입 시 보이는 화면
<img width="388" height="838" alt="image" src="https://github.com/user-attachments/assets/50800f3f-103d-4c48-b878-b3a8cb35a553" />


- "선택" 클릭 시 타임피커 바텀시트 노출
<img width="388" height="838" alt="image" src="https://github.com/user-attachments/assets/a610482c-eaa8-4d33-bc7f-8c6d971b88f2" />


- 오후 3:00 선택 시 15:00 으로 변환
<img width="388" height="838" alt="image" src="https://github.com/user-attachments/assets/1d7e372b-f08b-49ba-b1d0-58e9633a47d3" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 시간 입력 방식이 개선되었습니다. 바텀시트 형식의 전용 시간 선택기를 통해 오전/오후, 시간, 분을 편리하게 선택할 수 있으며, 선택된 시간은 HH:mm 형식으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->