### PR TITLE
[REFACTOR/#51] 캘린더 날짜 선택 시 요일 데이터 적용

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite01Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite01Fragment.kt
@@ -37,6 +37,7 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 class RecordWrite01Fragment : Fragment() {
 
@@ -48,7 +49,8 @@ class RecordWrite01Fragment : Fragment() {
 
     private var visibleMonth: YearMonth = YearMonth.now()
     private val headerFormatter = DateTimeFormatter.ofPattern(DATE_PATTERN)
-    private val displayFormatter = DateTimeFormatter.ofPattern(DATE_DISPLAY_PATTERN)
+    private val displayFormatter : DateTimeFormatter =
+        DateTimeFormatter.ofPattern(DATE_DISPLAY_PATTERN, Locale.KOREA)
 
     // 중복 호출 방지용 캐시: 마지막으로 서버에 요청했던 [시작일, 종료일]
     private var lastRequestedRange: Pair<Int, Int>? = null
@@ -351,7 +353,7 @@ class RecordWrite01Fragment : Fragment() {
 
     companion object {
         private const val DATE_PATTERN = "yyyy년 M월"
-        private const val DATE_DISPLAY_PATTERN = "yyyy-MM-dd"
+        private const val DATE_DISPLAY_PATTERN = "yyyy-MM-dd(E)"
     }
 
     private fun dpToPx(dp: Int): Int {


### PR DESCRIPTION
## 📝 작업 내용
날짜 선택하면 2025-11-18 형식으로 필드란 업데이트. -> 2025-11-18(화) 형식으로 변경하고 요일은 날짜값 기준으로 자동 계산

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 기록 작성 화면에서 날짜 표시 형식을 개선했습니다. 이제 날짜와 함께 요일 정보(예: 월, 화, 수)가 함께 표시되어 사용자가 더 직관적으로 날짜를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->