### PR TITLE
[Feat/#68] 특정 세션의 상담 데이터 삭제 api 연동

### DIFF
--- a/app/src/main/java/com/example/momolabfe/remote/consult/repository/ConsultRepository.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/consult/repository/ConsultRepository.kt
@@ -85,4 +85,13 @@ class ConsultRepository @Inject constructor(
         }
         response.body() ?: throw ApiException(response.code(), "빈 본문")
     }
+
+    // 특정 세션 상담 기록 삭제
+    suspend fun deleteConsult(sessionId: String): Result<Unit> = runCatching {
+        val response = consultService.deleteConsult(sessionId)
+        if (!response.isSuccessful) {
+            throw ApiException(response.code(), "특정 세션 상담 기록 삭제 실패: HTTP ${response.code()}")
+        }
+        Unit
+    }
 }

--- a/app/src/main/java/com/example/momolabfe/remote/consult/service/ConsultService.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/consult/service/ConsultService.kt
@@ -9,6 +9,7 @@ import com.example.momolabfe.remote.consult.data.StartConsultResponse
 import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -32,4 +33,7 @@ interface ConsultService {
 
     @GET("/api/v1/consults/history/{session_id}")
     suspend fun getConsult(@Path("session_id") sessionId: String): Response<List<ConsultDetailResponse>>
+
+    @DELETE("/api/v1/consults/{session_id}")
+    suspend fun deleteConsult(@Path("session_id") sessionId: String): Response<Unit>
 }

--- a/app/src/main/java/com/example/momolabfe/ui/consult/ConsultFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/ConsultFragment.kt
@@ -244,7 +244,7 @@ class ConsultFragment : Fragment() {
                     .commit()
             },
             onDelete = { item ->
-                // TODO: 삭제 API 연동 예정
+                viewModel.deleteConsult(item.sessionId)
             }
         )
 

--- a/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
@@ -156,6 +156,10 @@ class ConsultViewModel @Inject constructor(
         viewModelScope.launch {
             val result = consultRepository.deleteConsult(sessionId)
             result.onSuccess {
+                // 리스트 갱신
+                val current = _history.value.orEmpty()
+                _history.value = current.filterNot { it.sessionId == sessionId }
+
                 _deleteSuccess.tryEmit(Unit)
             }.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "특정 세션 상담 기록 삭제에 실패했습니다."

--- a/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
@@ -14,6 +14,9 @@ import com.example.momolabfe.remote.consult.data.StartConsultResponse
 import com.example.momolabfe.remote.consult.repository.ConsultRepository
 import com.example.momolabfe.ui.consult.data.ChatMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -36,6 +39,9 @@ class ConsultViewModel @Inject constructor(
 
     private val _consult = MutableLiveData<List<ConsultDetailResponse>>()
     val consult: LiveData<List<ConsultDetailResponse>> get() = _consult
+
+    private val _deleteSuccess = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val deleteSuccess: SharedFlow<Unit> = _deleteSuccess.asSharedFlow()
 
     // 에이전트 답변(스트리밍으로 누적)
     private val _agentMessage = MutableLiveData<String>()
@@ -141,6 +147,18 @@ class ConsultViewModel @Inject constructor(
                 _messages.value = mapped
             }.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "특정 상담 기록 상세 조회에 실패했습니다."
+            }
+        }
+    }
+
+    // 특정 세션 상담 기록 삭제
+    fun deleteConsult(sessionId: String) {
+        viewModelScope.launch {
+            val result = consultRepository.deleteConsult(sessionId)
+            result.onSuccess {
+                _deleteSuccess.tryEmit(Unit)
+            }.onFailure { e ->
+                _errorMessage.value = e.localizedMessage ?: "특정 세션 상담 기록 삭제에 실패했습니다."
             }
         }
     }


### PR DESCRIPTION
## 📝 작업 내용
특정 세션의 상담 데이터 삭제 api 연동하였습ㄴ다.
휴지통 버튼 클릭 시 기록 삭제
추후 "삭제하시겠습니까?" 모달창 띄울 생각 o

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 상담 기록에서 개별 상담 세션을 삭제할 수 있는 기능이 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->