### PR TITLE
[Refactor/#75] OCR 인식 시 미리보기 화면 배치

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -97,5 +97,5 @@ dependencies {
     implementation("com.github.PhilJay:MPAndroidChart:v3.1.0")
 
     // PhotoView
-    implementation("com.github.chrisbanes:PhotoView:2.3.0")
+    implementation("com.github.chrisbanes:PhotoView:2.2.0")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -95,4 +95,7 @@ dependencies {
 
     // MPAndroidChart
     implementation("com.github.PhilJay:MPAndroidChart:v3.1.0")
+
+    // PhotoView
+    implementation("com.github.chrisbanes:PhotoView:2.3.0")
 }

--- a/app/src/main/java/com/example/momolabfe/remote/record/model/RecordResponse.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/record/model/RecordResponse.kt
@@ -17,6 +17,7 @@ data class RecordGetResponse (
     @SerializedName("notes") val notes: String?,
     @SerializedName("total_uf") val totalUf: Int,
     @SerializedName("gcs_path") val gcsPath: String?,
+    @SerializedName("ocr_image_url") val ocrImageUrl: String?,
     @SerializedName("exchanges") val exchanges: List<RecordExchangeGetResponse> = emptyList()
 )
 

--- a/app/src/main/java/com/example/momolabfe/remote/record/repository/RecordRepository.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/record/repository/RecordRepository.kt
@@ -23,7 +23,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.ByteArrayOutputStream
-import java.io.IOException
 
 @Singleton
 class RecordRepository @Inject constructor(
@@ -113,19 +112,6 @@ class RecordRepository @Inject constructor(
         }
         response.body() ?: throw ApiException(response.code(), "빈 본문")
     }
-
-    // OCR 이미지 다운로드
-    suspend fun downloadOcrImage(gcsPath: String): Result<ByteArray> = runCatching {
-        val response = recordService.downloadOcrImage(gcsPath)
-
-        if (response.isSuccessful) {
-            response.body()?.bytes()
-                ?: throw IOException("서버에서 빈 이미지 데이터를 받았습니다.")
-        } else {
-            throw IOException("이미지 다운로드 실패: HTTP ${response.code()} ${response.message()}")
-        }
-    }
-
 
     // 헬퍼 메소드
     private fun makeFilePartFromUri(

--- a/app/src/main/java/com/example/momolabfe/remote/record/service/RecordService.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/record/service/RecordService.kt
@@ -10,7 +10,6 @@ import com.example.momolabfe.utils.ApiResponse
 import com.example.momolabfe.utils.AuthRetrofit
 import com.example.momolabfe.utils.PythonRetrofit
 import okhttp3.MultipartBody
-import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.http.Body
@@ -70,11 +69,6 @@ class RecordService @Inject constructor (
         @Multipart
         @POST("/api/v1/records/ocr")
         suspend fun recordByOcr(@Part file: MultipartBody.Part): Response<RecordOcrResponse>
-
-        // OCR 이미지 다운로드
-        @GET("/api/v1/records/ocr/image")
-        suspend fun downloadOcrImage(@Query("gcs_path") gcsPath: String): Response<ResponseBody>
-
     }
 
     // 내부 서비스 인스턴스 초기화
@@ -115,9 +109,5 @@ class RecordService @Inject constructor (
 
     suspend fun recordByOcr(file: MultipartBody.Part): Response<RecordOcrResponse> {
         return pythonService.recordByOcr(file)
-    }
-
-    suspend fun downloadOcrImage(gcsPath: String): Response<ResponseBody> {
-        return pythonService.downloadOcrImage(gcsPath)
     }
 }

--- a/app/src/main/java/com/example/momolabfe/ui/record/OcrImagePreviewFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/OcrImagePreviewFragment.kt
@@ -1,0 +1,66 @@
+package com.example.momolabfe.ui.record
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.bumptech.glide.Glide
+import com.example.momolabfe.R
+import com.example.momolabfe.databinding.FragmentOcrImagePreviewBinding
+
+class OcrImagePreviewFragment : Fragment() {
+
+    private var _binding: FragmentOcrImagePreviewBinding? = null
+    private val binding get() = _binding!!
+
+    private val imageUrl: String? by lazy {
+        arguments?.getString(ARG_IMAGE_URL)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentOcrImagePreviewBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        if (imageUrl.isNullOrBlank()) {
+            // URL 없으면 그냥 뒤로
+            parentFragmentManager.popBackStack()
+            return
+        }
+
+        Glide.with(this)
+            .load(imageUrl)
+            .placeholder(R.drawable.ic_thumbnail_sv)
+            .error(R.drawable.ic_thumbnail_sv)
+            .into(binding.ocrPhotoView)
+
+        binding.closeIv.setOnClickListener {
+            parentFragmentManager.popBackStack()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        private const val ARG_IMAGE_URL = "image_url"
+
+        fun newInstance(url: String): OcrImagePreviewFragment {
+            return OcrImagePreviewFragment().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_IMAGE_URL, url)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import com.bumptech.glide.Glide
 import com.example.momolabfe.R
 import com.example.momolabfe.databinding.FragmentRecordInfoBinding
 import com.example.momolabfe.databinding.ItemExchangeInfoBinding
@@ -94,6 +95,22 @@ class RecordInfoFragment : Fragment() {
                 renderExchangeInfo(recordItem)
 
                 applyUfValidation(recordItem)
+
+                val imageUrl = recordItem.ocrImageUrl
+
+                if (!imageUrl.isNullOrBlank()) {
+                    binding.ocrImageTitleTv.visibility = View.VISIBLE
+                    binding.ocrImageIv.visibility = View.VISIBLE
+
+                    Glide.with(requireContext())
+                        .load(imageUrl)
+                        .placeholder(R.drawable.ic_thumbnail_sv)
+                        .error(R.drawable.ic_thumbnail_sv)
+                        .into(binding.ocrImageIv)
+                } else {
+                    binding.ocrImageTitleTv.visibility = View.GONE
+                    binding.ocrImageIv.visibility = View.GONE
+                }
             }
         }
 

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
@@ -107,6 +107,15 @@ class RecordInfoFragment : Fragment() {
                         .placeholder(R.drawable.ic_thumbnail_sv)
                         .error(R.drawable.ic_thumbnail_sv)
                         .into(binding.ocrImageIv)
+
+                    // 클릭 시 전체 화면 프리뷰
+                    binding.ocrImageIv.setOnClickListener {
+                        val fragment = OcrImagePreviewFragment.newInstance(imageUrl)
+                        parentFragmentManager.beginTransaction()
+                            .add(R.id.main_frm, fragment) // 전체 화면 위에 쌓기
+                            .addToBackStack(null)
+                            .commit()
+                    }
                 } else {
                     binding.ocrImageTitleTv.visibility = View.GONE
                     binding.ocrImageIv.visibility = View.GONE

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
@@ -110,11 +110,14 @@ class RecordInfoFragment : Fragment() {
 
                     // 클릭 시 전체 화면 프리뷰
                     binding.ocrImageIv.setOnClickListener {
-                        val fragment = OcrImagePreviewFragment.newInstance(imageUrl)
-                        parentFragmentManager.beginTransaction()
-                            .add(R.id.main_frm, fragment) // 전체 화면 위에 쌓기
-                            .addToBackStack(null)
-                            .commit()
+                        val tag = "ocr_image_preview"
+                        if (parentFragmentManager.findFragmentByTag(tag) == null) {
+                            val fragment = OcrImagePreviewFragment.newInstance(imageUrl)
+                            parentFragmentManager.beginTransaction()
+                                .add(R.id.main_frm, fragment, tag) // 전체 화면 위에 쌓기
+                                .addToBackStack(null)
+                                .commit()
+                        }
                     }
                 } else {
                     binding.ocrImageTitleTv.visibility = View.GONE

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite01Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite01Fragment.kt
@@ -2,11 +2,9 @@ package com.example.momolabfe.ui.record
 
 import android.app.AlertDialog
 import android.content.res.ColorStateList
-import android.graphics.BitmapFactory
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
-import android.util.Log
 import android.util.TypedValue
 import android.view.Gravity
 import android.view.LayoutInflater
@@ -20,10 +18,7 @@ import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Observer
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import com.example.momolabfe.R
 import com.example.momolabfe.databinding.DialogCalendarBinding
 import com.example.momolabfe.databinding.FragmentRecordWrite01Binding
@@ -41,8 +36,6 @@ import com.kizitonwose.calendar.core.daysOfWeek
 import com.kizitonwose.calendar.view.CalendarView
 import com.kizitonwose.calendar.view.MonthDayBinder
 import com.kizitonwose.calendar.view.ViewContainer
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
@@ -99,10 +92,6 @@ class RecordWrite01Fragment : Fragment() {
         // 바텀 내비게이션 숨기기
         activity?.findViewById<BottomNavigationView>(R.id.main_bnv)?.visibility = View.GONE
 
-        if (!isOcrApplied) {
-            binding.ocrImagePreview.visibility = View.GONE
-        }
-
         // 최초 가시 월 기준으로 한 번 조회
         visibleMonth = YearMonth.now()
 
@@ -119,7 +108,6 @@ class RecordWrite01Fragment : Fragment() {
             collectDataAndCallApi()
         }
 
-        setupObservers()
         setupTurbidityCheckboxes()
         observeOcrAndFillFields()
     }
@@ -514,7 +502,8 @@ class RecordWrite01Fragment : Fragment() {
             fastingGlucose = fastingGlucose,
             urineCount = urineCount,
             turbidity = turbidityValue,
-            notes = notesText.takeIf { it.isNotBlank() }
+            notes = notesText.takeIf { it.isNotBlank() },
+            gcsPath = if (isFromOcr) viewModel.lastOcrGcsPath else null
         )
 
         val fragment = RecordWrite02Fragment().apply {
@@ -535,13 +524,11 @@ class RecordWrite01Fragment : Fragment() {
     private fun observeOcrAndFillFields() {
         viewModel.ocrRecordResult.observe(viewLifecycleOwner) { ocr ->
             if (!isFromOcr) {
-                binding.ocrImagePreview.visibility = View.GONE
                 return@observe
             }
 
             // null 이거나 이미 한 번 반영했다면 스킵
             if (ocr == null || isOcrApplied) {
-                binding.ocrImagePreview.visibility = View.GONE
                 return@observe
             }
 
@@ -568,38 +555,8 @@ class RecordWrite01Fragment : Fragment() {
             // gCS Path를 사용하여 이미지 다운로드 시작
             val gcsPath = ocr.gcsPath
             if (gcsPath.isNotEmpty()) {
-                viewModel.downloadOcrImage(gcsPath)
+                viewModel.lastOcrGcsPath = gcsPath
             }
-        }
-    }
-
-    private fun setupObservers() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.ocrImageBytes.collectLatest { imageBytes ->
-                    if (imageBytes != null) {
-                        try {
-                            // ByteArray를 Bitmap으로 변환하여 ImageView에 설정
-                            val bitmap =
-                                BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
-                            binding.ocrImagePreview.setImageBitmap(bitmap)
-                            binding.ocrImagePreview.visibility = View.VISIBLE
-                            Log.d("OCR_IMAGE", "OCR 이미지 로드 성공")
-                        } catch (e: Exception) {
-                            Log.e("OCR_IMAGE", "Bitmap 변환 실패: ${e.message}")
-                        }
-                    } else {
-                        if (!isOcrApplied) { // 수기 작성
-                            binding.ocrImagePreview.visibility = View.GONE
-                        }
-                    }
-                }
-            }
-        }
-
-        viewModel.errorMessage.observe(viewLifecycleOwner) { errorMsg ->
-            Log.e("RECORD_WRITE_01_FRAGMENT", errorMsg.toString())
-            binding.nextBtn.isEnabled = true
         }
     }
 

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite01Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite01Fragment.kt
@@ -15,6 +15,7 @@ import android.widget.CompoundButton
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -84,6 +85,35 @@ class RecordWrite01Fragment : Fragment() {
         }
 
         return binding.root
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        requireActivity().onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    showBackConfirmDialog()
+                }
+            }
+        )
+    }
+
+    private fun showBackConfirmDialog() {
+        AlertDialog.Builder(requireContext())
+            .setTitle("기록 작성 취소")
+            .setMessage("기록을 처음부터 다시 작성하시겠습니까?\n\n" +
+                    "현재까지 입력한 내용은 삭제됩니다.")
+            .setNegativeButton("아니오") { dialog, _ ->
+                dialog.dismiss()
+            }
+            .setPositiveButton("예") { dialog, _ ->
+                dialog.dismiss()
+                viewModel.clearOcr()
+                parentFragmentManager.popBackStack()
+            }
+            .show()
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
@@ -82,12 +82,6 @@ class RecordWrite02Fragment : Fragment() {
 
         fillExchangesFromOcr()
 
-        if (isFromOcr) {
-            downloadOcrImageIfAvailable()
-        } else {
-            binding.ocrImagePreview.visibility = View.GONE
-        }
-
         binding.addExchangeBtn.setOnClickListener {
             addExchange()
         }
@@ -468,17 +462,8 @@ class RecordWrite02Fragment : Fragment() {
         )
     }
 
-    private fun downloadOcrImageIfAvailable() {
-        val ocr = viewModel.ocrRecordResult.value
-
-        val gcsPath = ocr?.gcsPath
-        if (!gcsPath.isNullOrEmpty()) {
-            // gcs path를 사용하여 이미지 다운로드 시작
-            viewModel.downloadOcrImage(gcsPath)
-        }
-    }
-
     private fun setupObservers() {
+
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.recordSuccess.collectLatest {

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
@@ -467,6 +467,9 @@ class RecordWrite02Fragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.recordSuccess.collectLatest {
+                    // 기록 저장 성공 시에만 OCR 상태 정리
+                    viewModel.clearOcr()
+
                     parentFragmentManager.beginTransaction()
                         .replace(R.id.main_frm, RecordListFragment())
                         .commit()
@@ -543,7 +546,7 @@ class RecordWrite02Fragment : Fragment() {
     }
 
     private fun renderExchangeViews() {
-        val container = binding.exchangeContainer   // XML에서 RecyclerView → LinearLayout 로 바꾼 id
+        val container = binding.exchangeContainer
         container.removeAllViews()
 
         val inflater = LayoutInflater.from(requireContext())
@@ -551,31 +554,19 @@ class RecordWrite02Fragment : Fragment() {
         exchangeList.forEachIndexed { index, item ->
             val itemBinding = ItemRecordExchangeBinding.inflate(inflater, container, false)
 
-            // ① 회차 번호 (1회차, 2회차, ...)
             itemBinding.exchangeNoTv.text = "${index + 1}회차"
 
-            // ② 교환 시각
             val timeText = item.exchangeTime.format(TIME_FORMATTER)
             itemBinding.exchangeTimeEt.setText(timeText)
-
-            // 시간 선택기
             itemBinding.exchangeTimeEt.setOnClickListener {
                 showTimePickerDialog(itemBinding.exchangeTimeEt, index)
             }
 
-            // ③ 배액량
             itemBinding.drainVolumeEt.setText(item.drainVolume.toString())
-
-            // ④ 주입량
             itemBinding.fillVolumeEt.setText(item.fillVolume.toString())
-
-            // ⑤ 농도
             itemBinding.fillConcentrationEt.setText(item.fillConcentration.toString())
-
-            // ⑥ 제수량
             itemBinding.ufEt.setText(item.uf.toString())
 
-            // EditText 변경 시 exchangeList 동기화
             itemBinding.drainVolumeEt.addTextChangedListener {
                 val v = it?.toString()?.toIntOrNull() ?: 0
                 exchangeList[index] = exchangeList[index].copy(drainVolume = v)
@@ -604,7 +595,6 @@ class RecordWrite02Fragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        viewModel.clearOcr()
         _binding = null
     }
 }

--- a/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
@@ -178,29 +178,8 @@ class RecordViewModel @Inject constructor(
         }
     }
 
-    // ocr 이미지 다운로드
-    fun downloadOcrImage(gcsPath: String) {
-        viewModelScope.launch {
-            _ocrImageBytes.value = null // 다운로드 시작 전 StateFlow 초기화
-
-            val result = recordRepository.downloadOcrImage(gcsPath)
-
-            result.onSuccess { imageBytes ->
-                // 성공 시 ByteArray를 StateFlow에 저장
-                _ocrImageBytes.value = imageBytes
-                _errorMessage.value = null
-            }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "OCR 이미지 다운로드에 실패했습니다."
-            }
-        }
-    }
-
     fun setExchangeTime(time: String) {
         _exchangeTime.value = time
-    }
-
-    fun getExchangeTime(): String? {
-        return _exchangeTime.value
     }
 
     fun clearOcr() {

--- a/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
@@ -64,6 +64,9 @@ class RecordViewModel @Inject constructor(
     private val _calendarData = MutableLiveData<List<GetCalendarResponse>>()
     val calendarData: LiveData<List<GetCalendarResponse>> = _calendarData
 
+    // OCR로부터 마지막으로 받은 gcsPath를 보관
+    var lastOcrGcsPath: String? = null
+
     // 캘린더 일정 조회
     fun getCalendar(year: Int, month: Int) {
         viewModelScope.launch {

--- a/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
@@ -14,9 +14,7 @@ import com.example.momolabfe.remote.record.model.WeeklyAverageResponse
 import com.example.momolabfe.remote.record.repository.RecordRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -50,10 +48,6 @@ class RecordViewModel @Inject constructor(
 
     private val _ocrRecordResult = MutableLiveData<RecordOcrResponse?>()
     val ocrRecordResult: LiveData<RecordOcrResponse?> get() = _ocrRecordResult
-
-    // OCR 이미지 다운로드 결과 (다운로드된 이미지 파일의 바이트 배열)
-    private val _ocrImageBytes = MutableStateFlow<ByteArray?>(null)
-    val ocrImageBytes: StateFlow<ByteArray?> = _ocrImageBytes
 
     private val _editSuccess = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val editSuccess: SharedFlow<Unit> = _editSuccess.asSharedFlow()

--- a/app/src/main/res/layout/fragment_ocr_image_preview.xml
+++ b/app/src/main/res/layout/fragment_ocr_image_preview.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="#CC000000">

--- a/app/src/main/res/layout/fragment_ocr_image_preview.xml
+++ b/app/src/main/res/layout/fragment_ocr_image_preview.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#CC000000">
+
+    <com.github.chrisbanes.photoview.PhotoView
+        android:id="@+id/ocr_photo_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <ImageView
+        android:id="@+id/close_iv"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_marginTop="60dp"
+        android:layout_marginStart="20dp"
+        android:layout_gravity="top|start"
+        android:src="@drawable/ic_close_sv"/>
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_record_edit.xml
+++ b/app/src/main/res/layout/fragment_record_edit.xml
@@ -13,7 +13,7 @@
         android:layout_height="match_parent"
         android:clipToPadding="false"
         android:fillViewport="true"
-        android:paddingBottom="60dp">
+        android:paddingBottom="40dp">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_record_info.xml
+++ b/app/src/main/res/layout/fragment_record_info.xml
@@ -438,6 +438,37 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
+            <TextView
+                android:id="@+id/ocr_image_title_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="30dp"
+                android:fontFamily="@font/noto_sans_kr_medium"
+                android:includeFontPadding="false"
+                android:text="기록일지 이미지"
+                android:textColor="@color/text_primary"
+                android:textSize="16sp"
+                android:visibility="gone"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/exchange_info_section" />
+
+            <ImageView
+                android:id="@+id/ocr_image_iv"
+                android:layout_width="0dp"
+                android:layout_height="200dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginTop="10dp"
+                android:scaleType="centerCrop"
+                android:adjustViewBounds="true"
+                android:src="@drawable/ic_thumbnail_sv"
+                android:visibility="gone"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/ocr_image_title_tv"
+                app:layout_constraintBottom_toBottomOf="parent" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_record_write_01.xml
+++ b/app/src/main/res/layout/fragment_record_write_01.xml
@@ -56,19 +56,6 @@
                     app:layout_constraintStart_toStartOf="@id/title_tv"
                     app:layout_constraintTop_toBottomOf="@id/title_tv" />
 
-                <ImageView
-                    android:id="@+id/ocr_image_preview"
-                    android:layout_width="100dp"
-                    android:layout_height="0dp"
-                    android:layout_marginEnd="20dp"
-                    android:scaleType="centerCrop"
-                    android:src="@drawable/ic_thumbnail_sv"
-                    android:padding="0dp"
-                    android:elevation="4dp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent" />
-
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <com.google.android.material.card.MaterialCardView

--- a/app/src/main/res/layout/fragment_record_write_02.xml
+++ b/app/src/main/res/layout/fragment_record_write_02.xml
@@ -56,19 +56,6 @@
                     app:layout_constraintTop_toBottomOf="@id/title_tv"
                     app:layout_constraintBottom_toBottomOf="parent"/>
 
-                <ImageView
-                    android:id="@+id/ocr_image_preview"
-                    android:layout_width="100dp"
-                    android:layout_height="0dp"
-                    android:layout_marginEnd="20dp"
-                    android:scaleType="centerCrop"
-                    android:src="@drawable/ic_thumbnail_sv"
-                    android:padding="0dp"
-                    android:elevation="4dp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent" />
-
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <LinearLayout
@@ -109,7 +96,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="20dp"
-                android:layout_marginTop="5dp"
+                android:layout_marginTop="10dp"
                 android:layout_marginEnd="20dp"
                 android:layout_marginBottom="20dp"
                 android:backgroundTint="#EFF6FF"
@@ -165,7 +152,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="20dp"
-                android:layout_marginTop="10dp"
+                android:layout_marginTop="5dp"
                 android:layout_marginEnd="20dp"
                 android:layout_marginBottom="60dp"
                 android:backgroundTint="@color/main_1"


### PR DESCRIPTION
## 📝 작업 내용
OCR 인식 시 미리보기 화면을 배치하고, 클릭하면 이미지를 확대할 수 있는 기능을 제공합니다.

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * OCR 이미지 전체화면 미리보기(확대/축소/팬) 추가 및 관련 UI 요소 도입
  * 기록 정보 화면에서 OCR 이미지 노출 및 클릭으로 미리보기 실행

* **개선사항**
  * OCR 이미지 처리 흐름 단순화 및 작성 폼의 OCR 워크플로우 간소화
  * 기록 편집 레이아웃 소폭 조정(바텀 패딩 등)

* **변경/정리**
  * OCR 원격 이미지 직접 다운로드 기능 제거 및 관련 내부 상태 정리
  * OCR 이미지 경로 저장용 상태 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->