### PR TITLE
[Feat/#80] 오늘의 요약 api 연동

### DIFF
--- a/app/src/main/java/com/example/momolabfe/remote/record/model/RecordResponse.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/record/model/RecordResponse.kt
@@ -76,6 +76,7 @@ data class WeeklyAverageResponse (
 )
 
 data class TodayExchangeSummary (
+    @SerializedName("has_record") val hasRecord: Boolean,
     @SerializedName("exchange_count") val exchangeCount: Int,
     @SerializedName("total_uf") val totalUf: Int
 )

--- a/app/src/main/java/com/example/momolabfe/remote/record/model/RecordResponse.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/record/model/RecordResponse.kt
@@ -74,3 +74,8 @@ data class WeeklyAverageResponse (
     @SerializedName("end_date") val endDate: LocalDate,
     @SerializedName("data") val data: WeeklyAverageData
 )
+
+data class TodayExchangeSummary (
+    @SerializedName("exchange_count") val exchangeCount: Int,
+    @SerializedName("total_uf") val totalUf: Int
+)

--- a/app/src/main/java/com/example/momolabfe/remote/record/repository/RecordRepository.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/record/repository/RecordRepository.kt
@@ -9,6 +9,7 @@ import com.example.momolabfe.remote.record.model.RecordGetResponse
 import com.example.momolabfe.remote.record.model.RecordOcrResponse
 import com.example.momolabfe.remote.record.model.RecordUpdateRequest
 import com.example.momolabfe.remote.record.model.GetCalendarResponse
+import com.example.momolabfe.remote.record.model.TodayExchangeSummary
 import com.example.momolabfe.remote.record.model.WeeklyAverageResponse
 import com.example.momolabfe.remote.record.service.RecordService
 import com.example.momolabfe.utils.ApiException
@@ -90,6 +91,15 @@ class RecordRepository @Inject constructor(
         val response = recordService.getWeeklyAvgRecords(targetDate)
         if (!response.isSuccessful) {
             throw ApiException(response.code(), "주간 평균 기록 조회 실패: HTTP ${response.code()}")
+        }
+        response.body() ?: throw ApiException(response.code(), "빈 본문")
+    }
+
+    // 오늘의 요약 조회
+    suspend fun getTodayExchangeSummary(): Result<TodayExchangeSummary> = runCatching {
+        val response = recordService.getTodayExchangeSummary()
+        if (!response.isSuccessful) {
+            throw ApiException(response.code(), "오늘의 요약 조회 실패: HTTP ${response.code()}")
         }
         response.body() ?: throw ApiException(response.code(), "빈 본문")
     }

--- a/app/src/main/java/com/example/momolabfe/remote/record/service/RecordService.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/record/service/RecordService.kt
@@ -5,6 +5,7 @@ import com.example.momolabfe.remote.record.model.RecordCreateRequest
 import com.example.momolabfe.remote.record.model.RecordGetResponse
 import com.example.momolabfe.remote.record.model.RecordOcrResponse
 import com.example.momolabfe.remote.record.model.RecordUpdateRequest
+import com.example.momolabfe.remote.record.model.TodayExchangeSummary
 import com.example.momolabfe.remote.record.model.WeeklyAverageResponse
 import com.example.momolabfe.utils.ApiResponse
 import com.example.momolabfe.utils.AuthRetrofit
@@ -61,6 +62,10 @@ class RecordService @Inject constructor (
         @GET("/api/v1/records/weekly-average")
         suspend fun getWeeklyAvgRecords(@Query("target_date") targetDate: String? = null): Response<WeeklyAverageResponse>
 
+        // 오늘의 요약 조회
+        @GET("/api/v1/records/today-summary")
+        suspend fun getTodayExchangeSummary(): Response<TodayExchangeSummary>
+
         // 특정 기록 삭제
         @DELETE("/api/v1/records/{rec_id}")
         suspend fun deleteRecord(@Path("rec_id") recId: Long): Response<Unit>
@@ -101,6 +106,10 @@ class RecordService @Inject constructor (
 
     suspend fun getWeeklyAvgRecords(targetDate: String? = null): Response<WeeklyAverageResponse> {
         return pythonService.getWeeklyAvgRecords(targetDate)
+    }
+
+    suspend fun getTodayExchangeSummary(): Response<TodayExchangeSummary> {
+        return pythonService.getTodayExchangeSummary()
     }
 
     suspend fun deleteRecord(recId: Long): Response<Unit> {

--- a/app/src/main/java/com/example/momolabfe/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/main/HomeFragment.kt
@@ -95,14 +95,8 @@ class HomeFragment : Fragment() {
 
     private fun setupObservers() {
         viewModel.todayExchangeSummary.observe(viewLifecycleOwner) { summary ->
-            if (summary == null) {
+            if (summary == null || !summary.hasRecord) {
                 // 오늘 기록이 없을 때 기본 표시
-                binding.completeContentTv.text = "-회"
-                binding.ufContentTv.text = "-g"
-                return@observe
-            }
-
-            if (summary.exchangeCount == 0 && summary.totalUf == 0) {
                 binding.completeContentTv.text = "-회"
                 binding.ufContentTv.text = "-g"
                 return@observe

--- a/app/src/main/java/com/example/momolabfe/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/main/HomeFragment.kt
@@ -49,6 +49,7 @@ class HomeFragment : Fragment() {
         setupObservers()
         viewModel.getRecentRecords()
         viewModel.getWeeklyAvgRecords()
+        viewModel.getTodayExchangeSummary()
 
         try {
             // 날짜 포맷
@@ -93,6 +94,24 @@ class HomeFragment : Fragment() {
     }
 
     private fun setupObservers() {
+        viewModel.todayExchangeSummary.observe(viewLifecycleOwner) { summary ->
+            if (summary == null) {
+                // 오늘 기록이 없을 때 기본 표시
+                binding.completeContentTv.text = "-회"
+                binding.ufContentTv.text = "-g"
+                return@observe
+            }
+
+            if (summary.exchangeCount == 0 && summary.totalUf == 0) {
+                binding.completeContentTv.text = "-회"
+                binding.ufContentTv.text = "-g"
+                return@observe
+            }
+
+            binding.completeContentTv.text = "${summary.exchangeCount} / 5회"
+            binding.ufContentTv.text = String.format(Locale.KOREA, "%dg", summary.totalUf)
+        }
+
         viewModel.recordlistItems.observe(viewLifecycleOwner) { itemList ->
             val container = binding.recentRecordContainer
             container.removeAllViews()

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
@@ -17,6 +17,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -28,6 +29,7 @@ import com.example.momolabfe.databinding.FragmentRecordWrite02Binding
 import com.example.momolabfe.databinding.ItemRecordExchangeBinding
 import com.example.momolabfe.remote.record.model.RecordCreateRequest
 import com.example.momolabfe.remote.record.model.RecordExchangeCreateRequest
+import com.example.momolabfe.ui.main.HomeFragment
 import com.example.momolabfe.ui.record.data.RecordCommonDraft
 import com.example.momolabfe.ui.record.viewModel.RecordViewModel
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -470,8 +472,14 @@ class RecordWrite02Fragment : Fragment() {
                     // 기록 저장 성공 시에만 OCR 상태 정리
                     viewModel.clearOcr()
 
+                    // 기존 백스택 다 비우기
+                    parentFragmentManager.popBackStack(
+                        null,
+                        FragmentManager.POP_BACK_STACK_INCLUSIVE
+                    )
+
                     parentFragmentManager.beginTransaction()
-                        .replace(R.id.main_frm, RecordListFragment())
+                        .replace(R.id.main_frm, HomeFragment())
                         .commit()
                 }
             }

--- a/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
@@ -10,6 +10,7 @@ import com.example.momolabfe.remote.record.model.RecordCreateRequest
 import com.example.momolabfe.remote.record.model.RecordGetResponse
 import com.example.momolabfe.remote.record.model.RecordOcrResponse
 import com.example.momolabfe.remote.record.model.RecordUpdateRequest
+import com.example.momolabfe.remote.record.model.TodayExchangeSummary
 import com.example.momolabfe.remote.record.model.WeeklyAverageResponse
 import com.example.momolabfe.remote.record.repository.RecordRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -57,6 +58,9 @@ class RecordViewModel @Inject constructor(
 
     private val _calendarData = MutableLiveData<List<GetCalendarResponse>>()
     val calendarData: LiveData<List<GetCalendarResponse>> = _calendarData
+
+    private val _todayExchangeSummary = MutableLiveData<TodayExchangeSummary?>()
+    val todayExchangeSummary: LiveData<TodayExchangeSummary?> get() = _todayExchangeSummary
 
     // OCR로부터 마지막으로 받은 gcsPath를 보관
     var lastOcrGcsPath: String? = null
@@ -142,6 +146,18 @@ class RecordViewModel @Inject constructor(
                 _weeklyAverageData.value = weeklyAvgData
             }.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "주간 평균 기록 조회에 실패했습니다."
+            }
+        }
+    }
+
+    // 오늘의 요약 조회
+    fun getTodayExchangeSummary() {
+        viewModelScope.launch {
+            val result = recordRepository.getTodayExchangeSummary()
+            result.onSuccess { summary ->
+                _todayExchangeSummary.value = summary
+            }.onFailure { e ->
+                _errorMessage.value = e.localizedMessage ?: "오늘의 요약 조회에 실패했습니다."
             }
         }
     }


### PR DESCRIPTION
## 📝 작업 내용
오늘의 요약 api 연동
```
{
  "has_record": true,
  "exchange_count": 4,
  "total_uf": 500
}
``` 
+) 기록 작성 완료 시 기존 백스택을 비워서 기기의 뒤로가기 버튼을 클릭해도 작성 화면으로 돌아가지 않도록 처리

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 오늘의 교환 요약 정보 조회 기능 추가
  * 홈 화면에 일일 교환 횟수 및 UF 정보 표시
  
* **Improvements**
  * 기록 저장 후 홈 화면으로 자동 이동하도록 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->