### PR TITLE
[Feat/#81] 비밀번호 재설정 화면 제작 및 api 연동

### DIFF
--- a/app/src/main/java/com/example/momolabfe/remote/user/model/UserRequest.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/user/model/UserRequest.kt
@@ -1,0 +1,9 @@
+package com.example.momolabfe.remote.user.model
+
+import com.google.gson.annotations.SerializedName
+
+data class UpdatePassword (
+    @SerializedName("currentPassword") val currentPassword: String,
+    @SerializedName("newPassword") val newPassword: String,
+    @SerializedName("newPasswordCheck") val newPasswordCheck: String
+)

--- a/app/src/main/java/com/example/momolabfe/remote/user/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/user/repository/UserRepository.kt
@@ -2,8 +2,10 @@ package com.example.momolabfe.remote.user.repository
 
 import android.util.Log
 import com.example.momolabfe.remote.user.model.MyPageResponse
+import com.example.momolabfe.remote.user.model.UpdatePassword
 import com.example.momolabfe.remote.user.service.UserService
 import com.example.momolabfe.utils.handleApiResponse
+import com.example.momolabfe.utils.handleApiResponseUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,5 +18,11 @@ class UserRepository @Inject constructor (
         val response = userService.getMyPage()
         Log.d("GetMyPage", "MyPage API 호출 코드: ${response.code()}")
         handleApiResponse(response)
+    }
+
+    suspend fun updatePassword(request: UpdatePassword): Result<Unit> = runCatching {
+        val response = userService.updatePassword(request)
+        Log.d("UpdatePassword", "비밀번호 재설정 API 호출 코드: ${response.code()}")
+        handleApiResponseUnit(response)
     }
 }

--- a/app/src/main/java/com/example/momolabfe/remote/user/service/UserService.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/user/service/UserService.kt
@@ -1,12 +1,18 @@
 package com.example.momolabfe.remote.user.service
 
 import com.example.momolabfe.remote.user.model.MyPageResponse
+import com.example.momolabfe.remote.user.model.UpdatePassword
 import com.example.momolabfe.utils.ApiResponse
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 
 interface UserService {
 
     @GET("/api/v1/users/mypage")
     suspend fun getMyPage(): Response<ApiResponse<MyPageResponse>>
+
+    @PATCH("/api/v1/users/password")
+    suspend fun updatePassword(@Body request: UpdatePassword): Response<ApiResponse<Unit>>
 }

--- a/app/src/main/java/com/example/momolabfe/ui/setting/PasswordFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/PasswordFragment.kt
@@ -1,6 +1,7 @@
 package com.example.momolabfe.ui.setting
 
 import android.os.Bundle
+import android.text.InputType
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -8,11 +9,17 @@ import androidx.fragment.app.Fragment
 import com.example.momolabfe.R
 import com.example.momolabfe.databinding.FragmentPasswordBinding
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
 
 class PasswordFragment : Fragment() {
 
     private var _binding: FragmentPasswordBinding? = null
     private val binding get() = _binding!!
+
+    private var isCurrentPasswordVisible = false
+    private var isNewPasswordVisible = false
+    private var isNewPasswordCheckVisible = false
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -28,6 +35,64 @@ class PasswordFragment : Fragment() {
         // 바텀 내비게이션 숨기기
         activity?.findViewById<BottomNavigationView>(R.id.main_bnv)?.visibility = View.GONE
 
+        binding.cancelBtn.setOnClickListener {
+            parentFragmentManager.popBackStack()
+        }
+
+        setupPasswordToggle()
+    }
+
+    private fun setupPasswordToggle() {
+        // 현재 비밀번호
+        setupSinglePasswordToggle(
+            til = binding.currentPasswordTil,
+            et = binding.currentPasswordEt,
+            getVisible = { isCurrentPasswordVisible },
+            setVisible = { isCurrentPasswordVisible = it }
+        )
+
+        // 새 비밀번호
+        setupSinglePasswordToggle(
+            til = binding.newPasswordTil,
+            et = binding.newPasswordEt,
+            getVisible = { isNewPasswordVisible },
+            setVisible = { isNewPasswordVisible = it }
+        )
+
+        // 새 비밀번호 확인
+        setupSinglePasswordToggle(
+            til = binding.newPasswordCheckTil,
+            et = binding.newPasswordCheckEt,
+            getVisible = { isNewPasswordCheckVisible },
+            setVisible = { isNewPasswordCheckVisible = it }
+        )
+    }
+
+    private fun setupSinglePasswordToggle(
+        til: TextInputLayout,
+        et: TextInputEditText,
+        getVisible: () -> Boolean,
+        setVisible: (Boolean) -> Unit
+    ) {
+        til.setEndIconOnClickListener {
+            val newVisible = !getVisible()
+            setVisible(newVisible)
+
+            if (newVisible) {
+                // 비밀번호 보이기
+                et.inputType =
+                    InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
+                til.setEndIconDrawable(R.drawable.ic_eye_opened_sv)
+            } else {
+                // 비밀번호 숨기기
+                et.inputType =
+                    InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+                til.setEndIconDrawable(R.drawable.ic_eye_closed_sv)
+            }
+
+            // 커서를 텍스트 끝으로 이동
+            et.setSelection(et.text?.length ?: 0)
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/momolabfe/ui/setting/PasswordFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/PasswordFragment.kt
@@ -118,12 +118,12 @@ class PasswordFragment : Fragment() {
 
         // 입력 체크
         if (current.isEmpty() || newPw.isEmpty() || newPwCheck.isEmpty()) {
-            Toast.makeText(requireContext(), "모든 비밀번호 항목을 입력해주세요.", Toast.LENGTH_SHORT).show()
+            showError("모든 비밀번호 항목을 입력해주세요.")
             return
         }
 
         if (newPw != newPwCheck) {
-            Toast.makeText(requireContext(), "새 비밀번호와 확인이 일치하지 않습니다.", Toast.LENGTH_SHORT).show()
+            showError("새 비밀번호와 확인이 일치하지 않습니다.")
             return
         }
 
@@ -143,8 +143,8 @@ class PasswordFragment : Fragment() {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     viewModel.passwordSuccess.collect {
-                        Toast.makeText(requireContext(), "비밀번호가 변경되었습니다.", Toast.LENGTH_SHORT)
-                            .show()
+                        clearError()
+                        Toast.makeText(requireContext(), "비밀번호가 변경되었습니다.", Toast.LENGTH_SHORT).show()
                         binding.changeBtn.isEnabled = true
                         parentFragmentManager.popBackStack()
                     }
@@ -156,6 +156,17 @@ class PasswordFragment : Fragment() {
             Log.e("PASSWORD_FRAGMENT", errorMsg.toString())
             binding.changeBtn.isEnabled = true
         }
+    }
+
+    // 에러 표기
+    private fun showError(message: String) {
+        binding.passwordErrorTv.text = message
+        binding.passwordErrorTv.visibility = View.VISIBLE
+    }
+
+    private fun clearError() {
+        binding.passwordErrorTv.text = ""
+        binding.passwordErrorTv.visibility = View.GONE
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/momolabfe/ui/setting/PasswordFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/PasswordFragment.kt
@@ -1,0 +1,37 @@
+package com.example.momolabfe.ui.setting
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.example.momolabfe.R
+import com.example.momolabfe.databinding.FragmentPasswordBinding
+import com.google.android.material.bottomnavigation.BottomNavigationView
+
+class PasswordFragment : Fragment() {
+
+    private var _binding: FragmentPasswordBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentPasswordBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // 바텀 내비게이션 숨기기
+        activity?.findViewById<BottomNavigationView>(R.id.main_bnv)?.visibility = View.GONE
+
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/example/momolabfe/ui/setting/PasswordFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/PasswordFragment.kt
@@ -112,6 +112,8 @@ class PasswordFragment : Fragment() {
     }
 
     private fun submitPasswordChange() {
+        clearError() // 이전 에러 초기화
+
         val current = binding.currentPasswordEt.text?.toString()?.trim() ?: ""
         val newPw = binding.newPasswordEt.text?.toString()?.trim() ?: ""
         val newPwCheck = binding.newPasswordCheckEt.text?.toString()?.trim() ?: ""

--- a/app/src/main/java/com/example/momolabfe/ui/setting/PasswordFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/PasswordFragment.kt
@@ -2,15 +2,24 @@ package com.example.momolabfe.ui.setting
 
 import android.os.Bundle
 import android.text.InputType
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.example.momolabfe.R
 import com.example.momolabfe.databinding.FragmentPasswordBinding
+import com.example.momolabfe.remote.user.model.UpdatePassword
+import com.example.momolabfe.ui.setting.viewModel.SettingViewModel
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
+import kotlinx.coroutines.launch
 
 class PasswordFragment : Fragment() {
 
@@ -20,6 +29,8 @@ class PasswordFragment : Fragment() {
     private var isCurrentPasswordVisible = false
     private var isNewPasswordVisible = false
     private var isNewPasswordCheckVisible = false
+
+    private val viewModel: SettingViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -35,11 +46,16 @@ class PasswordFragment : Fragment() {
         // 바텀 내비게이션 숨기기
         activity?.findViewById<BottomNavigationView>(R.id.main_bnv)?.visibility = View.GONE
 
+        setupPasswordToggle()
+        setupObservers()
+
         binding.cancelBtn.setOnClickListener {
             parentFragmentManager.popBackStack()
         }
 
-        setupPasswordToggle()
+        binding.changeBtn.setOnClickListener {
+            submitPasswordChange()
+        }
     }
 
     private fun setupPasswordToggle() {
@@ -92,6 +108,53 @@ class PasswordFragment : Fragment() {
 
             // 커서를 텍스트 끝으로 이동
             et.setSelection(et.text?.length ?: 0)
+        }
+    }
+
+    private fun submitPasswordChange() {
+        val current = binding.currentPasswordEt.text?.toString()?.trim() ?: ""
+        val newPw = binding.newPasswordEt.text?.toString()?.trim() ?: ""
+        val newPwCheck = binding.newPasswordCheckEt.text?.toString()?.trim() ?: ""
+
+        // 입력 체크
+        if (current.isEmpty() || newPw.isEmpty() || newPwCheck.isEmpty()) {
+            Toast.makeText(requireContext(), "모든 비밀번호 항목을 입력해주세요.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        if (newPw != newPwCheck) {
+            Toast.makeText(requireContext(), "새 비밀번호와 확인이 일치하지 않습니다.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val request = UpdatePassword(
+            currentPassword = current,
+            newPassword = newPw,
+            newPasswordCheck = newPwCheck
+        )
+
+        binding.changeBtn.isEnabled = false
+
+        viewModel.updatePassword(request)
+    }
+
+    private fun setupObservers() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.passwordSuccess.collect {
+                        Toast.makeText(requireContext(), "비밀번호가 변경되었습니다.", Toast.LENGTH_SHORT)
+                            .show()
+                        binding.changeBtn.isEnabled = true
+                        parentFragmentManager.popBackStack()
+                    }
+                }
+            }
+        }
+
+        viewModel.errorMessage.observe(viewLifecycleOwner) { errorMsg ->
+            Log.e("PASSWORD_FRAGMENT", errorMsg.toString())
+            binding.changeBtn.isEnabled = true
         }
     }
 

--- a/app/src/main/java/com/example/momolabfe/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/SettingFragment.kt
@@ -50,25 +50,22 @@ class SettingFragment : Fragment() {
         viewModel.getMyPage()
         observeMyPageResult()
 
-        binding.changePasswordTitleTv.setOnClickListener {
-            parentFragmentManager.beginTransaction()
-                .replace(R.id.main_frm, PasswordFragment())
-                .addToBackStack(null)
-                .commit()
-        }
+        binding.changePasswordTitleTv.setOnClickListener { navigateToPassword() }
 
-        binding.changePasswordContentTv.setOnClickListener {
-            parentFragmentManager.beginTransaction()
-                .replace(R.id.main_frm, PasswordFragment())
-                .addToBackStack(null)
-                .commit()
-        }
+        binding.changePasswordContentTv.setOnClickListener { navigateToPassword() }
 
         binding.logoutBtn.setOnClickListener {
             viewLifecycleOwner.lifecycleScope.launch {
                 logoutManager.logout()
             }
         }
+    }
+
+    private fun navigateToPassword() {
+        parentFragmentManager.beginTransaction()
+            .replace(R.id.main_frm, PasswordFragment())
+            .addToBackStack(null)
+            .commit()
     }
 
     private fun observeMyPageResult() {

--- a/app/src/main/java/com/example/momolabfe/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/SettingFragment.kt
@@ -50,6 +50,13 @@ class SettingFragment : Fragment() {
         viewModel.getMyPage()
         observeMyPageResult()
 
+        binding.changePasswordTitleTv.setOnClickListener {
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.main_frm, PasswordFragment())
+                .addToBackStack(null)
+                .commit()
+        }
+
         binding.changePasswordContentTv.setOnClickListener {
             parentFragmentManager.beginTransaction()
                 .replace(R.id.main_frm, PasswordFragment())

--- a/app/src/main/java/com/example/momolabfe/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/SettingFragment.kt
@@ -50,6 +50,13 @@ class SettingFragment : Fragment() {
         viewModel.getMyPage()
         observeMyPageResult()
 
+        binding.changePasswordContentTv.setOnClickListener {
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.main_frm, PasswordFragment())
+                .addToBackStack(null)
+                .commit()
+        }
+
         binding.logoutBtn.setOnClickListener {
             viewLifecycleOwner.lifecycleScope.launch {
                 logoutManager.logout()

--- a/app/src/main/java/com/example/momolabfe/ui/setting/viewModel/SettingViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/viewModel/SettingViewModel.kt
@@ -5,8 +5,12 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.momolabfe.remote.user.model.MyPageResponse
+import com.example.momolabfe.remote.user.model.UpdatePassword
 import com.example.momolabfe.remote.user.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -18,8 +22,14 @@ class SettingViewModel @Inject constructor(
     private val _errorMessage = MutableLiveData<String?>()
     val errorMessage: LiveData<String?> get() = _errorMessage
 
+    private val _passwordSuccess = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val passwordSuccess: SharedFlow<Unit> = _passwordSuccess.asSharedFlow()
+
     private val _getPageResult = MutableLiveData<MyPageResponse>()
     val getPageResult: LiveData<MyPageResponse> get() = _getPageResult
+
+    private val _passwordResult = MutableLiveData<Unit?>()
+    val passwordResult: LiveData<Unit?> get() = _passwordResult
 
     // 마이페이지 조회
     fun getMyPage() {
@@ -29,6 +39,18 @@ class SettingViewModel @Inject constructor(
                 _getPageResult.value = it
             }.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "마이페이지 조회에 실패했습니다."
+            }
+        }
+    }
+
+    // 비밀번호 재설정
+    fun updatePassword(request: UpdatePassword) {
+        viewModelScope.launch {
+            val result = userRepository.updatePassword(request)
+            result.onSuccess {
+                _passwordSuccess.tryEmit(Unit)
+            }.onFailure { e ->
+                _errorMessage.value = e.localizedMessage ?: "비밀번호 재설정에 실패했습니다."
             }
         }
     }

--- a/app/src/main/res/drawable/ic_lock_sv.xml
+++ b/app/src/main/res/drawable/ic_lock_sv.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="25dp"
+    android:height="25dp"
+    android:viewportWidth="25"
+    android:viewportHeight="25">
+  <path
+      android:pathData="M8.333,10.417H6.25C5.697,10.417 5.168,10.636 4.777,11.027C4.386,11.418 4.167,11.948 4.167,12.5V19.792C4.167,20.344 4.386,20.874 4.777,21.265C5.168,21.656 5.697,21.875 6.25,21.875H18.75C19.303,21.875 19.833,21.656 20.223,21.265C20.614,20.874 20.833,20.344 20.833,19.792V12.5C20.833,11.948 20.614,11.418 20.223,11.027C19.833,10.636 19.303,10.417 18.75,10.417H16.667M8.333,10.417V7.292C8.333,6.187 8.772,5.127 9.554,4.345C10.335,3.564 11.395,3.125 12.5,3.125C13.605,3.125 14.665,3.564 15.446,4.345C16.228,5.127 16.667,6.187 16.667,7.292V10.417M8.333,10.417H16.667M12.5,14.583V17.708"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2.08333"
+      android:fillColor="#00000000"
+      android:strokeColor="#155DFC"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/layout/fragment_password.xml
+++ b/app/src/main/res/layout/fragment_password.xml
@@ -1,0 +1,414 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/main_bg"
+    tools:context=".ui.setting.SettingFragment">
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/scroll_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:paddingBottom="70dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="60dp"
+            android:orientation="vertical">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/title_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/bg_gradient"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <TextView
+                    android:id="@+id/title_tv"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="20dp"
+                    android:layout_marginTop="20dp"
+                    android:fontFamily="@font/noto_sans_kr_medium"
+                    android:includeFontPadding="false"
+                    android:text="비밀번호 변경"
+                    android:textColor="@color/white"
+                    android:textSize="18sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/content_tv"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="20dp"
+                    android:fontFamily="@font/noto_sans_kr_regular"
+                    android:includeFontPadding="false"
+                    android:text="환자의 비밀번호를 변경합니다."
+                    android:textColor="@color/white"
+                    android:textSize="17sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="@id/title_tv"
+                    app:layout_constraintTop_toBottomOf="@id/title_tv" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/password_info_cv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="10dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="40dp"
+                android:layout_marginEnd="20dp"
+                android:backgroundTint="@color/white"
+                app:cardCornerRadius="10dp"
+                app:cardElevation="0dp"
+                app:layout_constraintTop_toBottomOf="@id/title_container"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:strokeWidth="0dp">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="#C7DFFF">
+
+                    <ImageView
+                        android:id="@+id/password_iv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="15dp"
+                        android:layout_marginStart="15dp"
+                        android:src="@drawable/ic_lock_sv"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"/>
+
+                    <TextView
+                        android:id="@+id/password_title_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="15dp"
+                        android:fontFamily="@font/noto_sans_kr_regular"
+                        android:text="비밀번호 변경 안내"
+                        android:textColor="@color/text_primary"
+                        android:textSize="15sp"
+                        android:includeFontPadding="false"
+                        app:layout_constraintStart_toEndOf="@id/password_iv"
+                        app:layout_constraintTop_toTopOf="@id/password_iv" />
+
+                    <TextView
+                        android:id="@+id/password_content_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="10dp"
+                        android:layout_marginBottom="20dp"
+                        android:text="@string/password_info"
+                        android:fontFamily="@font/noto_sans_kr_regular"
+                        android:textColor="@color/secondary_text"
+                        android:textSize="15sp"
+                        android:includeFontPadding="false"
+                        app:layout_constraintTop_toBottomOf="@id/password_title_tv"
+                        app:layout_constraintStart_toStartOf="@id/password_title_tv"
+                        app:layout_constraintBottom_toBottomOf="parent"/>
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/password_cv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="20dp"
+                android:layout_marginEnd="20dp"
+                android:backgroundTint="@color/white"
+                app:cardCornerRadius="10dp"
+                app:cardElevation="0dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/password_info_cv"
+                app:strokeWidth="0dp">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@color/white">
+
+                    <TextView
+                        android:id="@+id/password_info_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="20dp"
+                        android:layout_marginStart="25dp"
+                        android:text="비밀번호 정보"
+                        android:textColor="@color/text_primary"
+                        android:textSize="16sp"
+                        android:includeFontPadding="false"
+                        android:fontFamily="@font/noto_sans_kr_medium"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"/>
+
+                    <TextView
+                        android:id="@+id/current_password_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="25dp"
+                        android:text="현재 비밀번호"
+                        android:textSize="16sp"
+                        android:includeFontPadding="false"
+                        android:fontFamily="@font/noto_sans_kr_regular"
+                        android:textColor="@color/text_primary"
+                        app:layout_constraintTop_toBottomOf="@id/password_info_tv"
+                        app:layout_constraintStart_toStartOf="@id/password_info_tv"/>
+
+                    <androidx.cardview.widget.CardView
+                        android:id="@+id/current_password_value_cv"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:layout_marginEnd="20dp"
+                        android:backgroundTint="@color/edit_card"
+                        app:cardCornerRadius="8dp"
+                        app:cardElevation="0dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="@id/current_password_tv"
+                        app:layout_constraintTop_toBottomOf="@id/current_password_tv">
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:padding="12dp">
+
+                            <EditText
+                                android:id="@+id/current_password_value_et"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:background="@color/transparent"
+                                android:hint="현재 비밀번호를 입력하세요"
+                                android:inputType="textPassword"
+                                android:textSize="16sp" />
+
+                        </LinearLayout>
+                    </androidx.cardview.widget.CardView>
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/current_password_value_til"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        app:boxBackgroundMode="outline"
+                        app:boxBackgroundColor="@color/edit_card"
+                        app:boxCornerRadiusTopStart="12dp"
+                        app:boxCornerRadiusTopEnd="12dp"
+                        app:boxCornerRadiusBottomStart="12dp"
+                        app:boxCornerRadiusBottomEnd="12dp"
+                        app:endIconMode="custom"
+                        app:endIconDrawable="@drawable/ic_eye_closed_sv"
+                        app:layout_constraintTop_toBottomOf="@id/current_password_tv">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/current_password_et"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:inputType="textPassword"
+                            android:textSize="14sp"
+                            android:paddingTop="10dp"
+                            android:paddingBottom="10dp"
+                            android:background="@color/transparent"/>
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <TextView
+                        android:id="@+id/new_password_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="새 비밀번호"
+                        android:layout_marginTop="15dp"
+                        android:textSize="16sp"
+                        android:includeFontPadding="false"
+                        android:fontFamily="@font/noto_sans_kr_regular"
+                        android:textColor="@color/text_primary"
+                        app:layout_constraintTop_toBottomOf="@id/current_password_value_cv"
+                        app:layout_constraintStart_toStartOf="@id/current_password_value_cv"/>
+
+                    <androidx.cardview.widget.CardView
+                        android:id="@+id/new_password_value_cv"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:layout_marginEnd="20dp"
+                        android:backgroundTint="@color/edit_card"
+                        app:cardCornerRadius="8dp"
+                        app:cardElevation="0dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="@id/current_password_tv"
+                        app:layout_constraintTop_toBottomOf="@id/new_password_tv">
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:padding="12dp">
+
+                            <EditText
+                                android:id="@+id/new_password_value_et"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:background="@color/transparent"
+                                android:hint="새 비밀번호를 입력하세요"
+                                android:inputType="textPassword"
+                                android:textSize="16sp" />
+
+                        </LinearLayout>
+                    </androidx.cardview.widget.CardView>
+
+                    <TextView
+                        android:id="@+id/new_password_check_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="새 비밀번호 확인"
+                        android:layout_marginTop="15dp"
+                        android:textSize="16sp"
+                        android:includeFontPadding="false"
+                        android:fontFamily="@font/noto_sans_kr_regular"
+                        android:textColor="@color/text_primary"
+                        app:layout_constraintTop_toBottomOf="@id/new_password_value_cv"
+                        app:layout_constraintStart_toStartOf="@id/current_password_value_cv"/>
+
+                    <androidx.cardview.widget.CardView
+                        android:id="@+id/new_password_check_value_cv"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:layout_marginEnd="20dp"
+                        android:backgroundTint="@color/edit_card"
+                        app:cardCornerRadius="8dp"
+                        app:cardElevation="0dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="@id/current_password_tv"
+                        app:layout_constraintTop_toBottomOf="@id/new_password_check_tv">
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:padding="12dp">
+
+                            <EditText
+                                android:id="@+id/new_password_check_value_et"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:background="@color/transparent"
+                                android:hint="새 비밀번호를 다시 입력하세요"
+                                android:inputType="textPassword"
+                                android:textSize="16sp" />
+
+                        </LinearLayout>
+                    </androidx.cardview.widget.CardView>
+
+                    <LinearLayout
+                        android:id="@+id/bottom_bar"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="30dp"
+                        android:layout_marginStart="19dp"
+                        android:layout_marginEnd="19dp"
+                        android:layout_marginBottom="20dp"
+                        android:orientation="horizontal"
+                        android:weightSum="2"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/new_password_check_value_cv">
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/cancel_btn"
+                            android:layout_width="0dp"
+                            android:layout_height="65dp"
+                            android:layout_marginEnd="8dp"
+                            android:layout_weight="1"
+                            android:text="취소"
+                            app:strokeWidth="1dp"
+                            app:strokeColor="@color/main_bg"
+                            android:textColor="@color/text_primary"
+                            app:backgroundTint="@color/white"
+                            app:cornerRadius="12dp" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/change_btn"
+                            android:layout_width="0dp"
+                            android:layout_height="65dp"
+                            android:layout_marginStart="8dp"
+                            android:layout_weight="1"
+                            android:text="변경하기"
+                            android:textColor="@color/white"
+                            app:backgroundTint="@color/main_1"
+                            app:cornerRadius="12dp" />
+                    </LinearLayout>
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/security_tip_cv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="20dp"
+                android:layout_marginEnd="20dp"
+                android:backgroundTint="@color/white"
+                app:cardCornerRadius="10dp"
+                app:cardElevation="0dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/password_cv"
+                app:strokeWidth="0dp">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@color/white">
+
+                    <TextView
+                        android:id="@+id/security_tip_title_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="20dp"
+                        android:layout_marginStart="25dp"
+                        android:text="보안 팁"
+                        android:textSize="16sp"
+                        android:includeFontPadding="false"
+                        android:fontFamily="@font/noto_sans_kr_medium"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"/>
+
+                    <TextView
+                        android:id="@+id/security_tip_content_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="30dp"
+                        android:layout_marginBottom="20dp"
+                        android:text="@string/security_tip"
+                        android:fontFamily="@font/noto_sans_kr_regular"
+                        android:textColor="@color/secondary_text"
+                        android:textSize="15sp"
+                        android:includeFontPadding="false"
+                        app:layout_constraintTop_toBottomOf="@id/security_tip_title_tv"
+                        app:layout_constraintStart_toStartOf="@id/security_tip_title_tv"
+                        app:layout_constraintBottom_toBottomOf="parent"/>
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_password.xml
+++ b/app/src/main/res/layout/fragment_password.xml
@@ -167,57 +167,30 @@
                         app:layout_constraintTop_toBottomOf="@id/password_info_tv"
                         app:layout_constraintStart_toStartOf="@id/password_info_tv"/>
 
-                    <androidx.cardview.widget.CardView
-                        android:id="@+id/current_password_value_cv"
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/current_password_til"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        android:layout_marginEnd="20dp"
-                        android:backgroundTint="@color/edit_card"
-                        app:cardCornerRadius="8dp"
-                        app:cardElevation="0dp"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toStartOf="@id/current_password_tv"
-                        app:layout_constraintTop_toBottomOf="@id/current_password_tv">
-
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:orientation="horizontal"
-                            android:padding="12dp">
-
-                            <EditText
-                                android:id="@+id/current_password_value_et"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1"
-                                android:background="@color/transparent"
-                                android:hint="현재 비밀번호를 입력하세요"
-                                android:inputType="textPassword"
-                                android:textSize="16sp" />
-
-                        </LinearLayout>
-                    </androidx.cardview.widget.CardView>
-
-                    <com.google.android.material.textfield.TextInputLayout
-                        android:id="@+id/current_password_value_til"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="10dp"
                         android:layout_gravity="center_vertical"
-                        app:boxBackgroundMode="outline"
-                        app:boxBackgroundColor="@color/edit_card"
+                        app:boxBackgroundMode="filled"
+                        app:boxBackgroundColor="@color/gray"
                         app:boxCornerRadiusTopStart="12dp"
                         app:boxCornerRadiusTopEnd="12dp"
                         app:boxCornerRadiusBottomStart="12dp"
                         app:boxCornerRadiusBottomEnd="12dp"
                         app:endIconMode="custom"
                         app:endIconDrawable="@drawable/ic_eye_closed_sv"
-                        app:layout_constraintTop_toBottomOf="@id/current_password_tv">
+                        app:layout_constraintTop_toBottomOf="@id/current_password_tv"
+                        app:layout_constraintStart_toStartOf="@id/current_password_tv"
+                        app:layout_constraintEnd_toEndOf="parent">
 
                         <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/current_password_et"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
+                            android:hint="현재 비밀번호를 입력하세요"
+                            android:paddingStart="0dp"
                             android:inputType="textPassword"
                             android:textSize="14sp"
                             android:paddingTop="10dp"
@@ -235,40 +208,39 @@
                         android:includeFontPadding="false"
                         android:fontFamily="@font/noto_sans_kr_regular"
                         android:textColor="@color/text_primary"
-                        app:layout_constraintTop_toBottomOf="@id/current_password_value_cv"
-                        app:layout_constraintStart_toStartOf="@id/current_password_value_cv"/>
+                        app:layout_constraintTop_toBottomOf="@id/current_password_til"
+                        app:layout_constraintStart_toStartOf="@id/current_password_til"/>
 
-                    <androidx.cardview.widget.CardView
-                        android:id="@+id/new_password_value_cv"
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/new_password_til"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        android:layout_marginEnd="20dp"
-                        android:backgroundTint="@color/edit_card"
-                        app:cardCornerRadius="8dp"
-                        app:cardElevation="0dp"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toStartOf="@id/current_password_tv"
-                        app:layout_constraintTop_toBottomOf="@id/new_password_tv">
+                        android:layout_marginEnd="10dp"
+                        android:layout_gravity="center_vertical"
+                        app:boxBackgroundMode="filled"
+                        app:boxBackgroundColor="@color/gray"
+                        app:boxCornerRadiusTopStart="12dp"
+                        app:boxCornerRadiusTopEnd="12dp"
+                        app:boxCornerRadiusBottomStart="12dp"
+                        app:boxCornerRadiusBottomEnd="12dp"
+                        app:endIconMode="custom"
+                        app:endIconDrawable="@drawable/ic_eye_closed_sv"
+                        app:layout_constraintTop_toBottomOf="@id/new_password_tv"
+                        app:layout_constraintStart_toStartOf="@id/new_password_tv"
+                        app:layout_constraintEnd_toEndOf="parent">
 
-                        <LinearLayout
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/new_password_et"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:orientation="horizontal"
-                            android:padding="12dp">
-
-                            <EditText
-                                android:id="@+id/new_password_value_et"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1"
-                                android:background="@color/transparent"
-                                android:hint="새 비밀번호를 입력하세요"
-                                android:inputType="textPassword"
-                                android:textSize="16sp" />
-
-                        </LinearLayout>
-                    </androidx.cardview.widget.CardView>
+                            android:hint="새 비밀번호를 입력하세요"
+                            android:paddingStart="0dp"
+                            android:inputType="textPassword"
+                            android:textSize="14sp"
+                            android:paddingTop="10dp"
+                            android:paddingBottom="10dp"
+                            android:background="@color/transparent"/>
+                    </com.google.android.material.textfield.TextInputLayout>
 
                     <TextView
                         android:id="@+id/new_password_check_tv"
@@ -280,40 +252,39 @@
                         android:includeFontPadding="false"
                         android:fontFamily="@font/noto_sans_kr_regular"
                         android:textColor="@color/text_primary"
-                        app:layout_constraintTop_toBottomOf="@id/new_password_value_cv"
-                        app:layout_constraintStart_toStartOf="@id/current_password_value_cv"/>
+                        app:layout_constraintTop_toBottomOf="@id/new_password_til"
+                        app:layout_constraintStart_toStartOf="@id/new_password_til"/>
 
-                    <androidx.cardview.widget.CardView
-                        android:id="@+id/new_password_check_value_cv"
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/new_password_check_til"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        android:layout_marginEnd="20dp"
-                        android:backgroundTint="@color/edit_card"
-                        app:cardCornerRadius="8dp"
-                        app:cardElevation="0dp"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toStartOf="@id/current_password_tv"
-                        app:layout_constraintTop_toBottomOf="@id/new_password_check_tv">
+                        android:layout_marginEnd="10dp"
+                        android:layout_gravity="center_vertical"
+                        app:boxBackgroundMode="filled"
+                        app:boxBackgroundColor="@color/gray"
+                        app:boxCornerRadiusTopStart="12dp"
+                        app:boxCornerRadiusTopEnd="12dp"
+                        app:boxCornerRadiusBottomStart="12dp"
+                        app:boxCornerRadiusBottomEnd="12dp"
+                        app:endIconMode="custom"
+                        app:endIconDrawable="@drawable/ic_eye_closed_sv"
+                        app:layout_constraintTop_toBottomOf="@id/new_password_check_tv"
+                        app:layout_constraintStart_toStartOf="@id/new_password_check_tv"
+                        app:layout_constraintEnd_toEndOf="parent">
 
-                        <LinearLayout
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/new_password_check_et"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:orientation="horizontal"
-                            android:padding="12dp">
-
-                            <EditText
-                                android:id="@+id/new_password_check_value_et"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1"
-                                android:background="@color/transparent"
-                                android:hint="새 비밀번호를 다시 입력하세요"
-                                android:inputType="textPassword"
-                                android:textSize="16sp" />
-
-                        </LinearLayout>
-                    </androidx.cardview.widget.CardView>
+                            android:hint="새 비밀번호를 다시 입력하세요"
+                            android:paddingStart="0dp"
+                            android:inputType="textPassword"
+                            android:textSize="14sp"
+                            android:paddingTop="10dp"
+                            android:paddingBottom="10dp"
+                            android:background="@color/transparent"/>
+                    </com.google.android.material.textfield.TextInputLayout>
 
                     <LinearLayout
                         android:id="@+id/bottom_bar"
@@ -328,7 +299,7 @@
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/new_password_check_value_cv">
+                        app:layout_constraintTop_toBottomOf="@id/new_password_check_til">
 
                         <com.google.android.material.button.MaterialButton
                             android:id="@+id/cancel_btn"

--- a/app/src/main/res/layout/fragment_password.xml
+++ b/app/src/main/res/layout/fragment_password.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/main_bg"
-    tools:context=".ui.setting.SettingFragment">
+    tools:context=".ui.setting.PasswordFragment">
 
     <androidx.core.widget.NestedScrollView
         android:id="@+id/scroll_container"
@@ -286,6 +286,22 @@
                             android:background="@color/transparent"/>
                     </com.google.android.material.textfield.TextInputLayout>
 
+                    <TextView
+                        android:id="@+id/password_error_tv"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:layout_marginStart="25dp"
+                        android:layout_marginEnd="25dp"
+                        android:textColor="@color/red"
+                        android:textSize="13sp"
+                        android:includeFontPadding="false"
+                        android:fontFamily="@font/noto_sans_kr_regular"
+                        android:visibility="gone"
+                        app:layout_constraintTop_toBottomOf="@id/new_password_check_til"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent" />
+
                     <LinearLayout
                         android:id="@+id/bottom_bar"
                         android:layout_width="match_parent"
@@ -299,7 +315,7 @@
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/new_password_check_til">
+                        app:layout_constraintTop_toBottomOf="@id/password_error_tv">
 
                         <com.google.android.material.button.MaterialButton
                             android:id="@+id/cancel_btn"

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -106,7 +106,7 @@
                         android:layout_height="wrap_content"
                         android:layout_marginHorizontal="10dp"
                         android:layout_marginStart="20dp"
-                        android:layout_marginTop="40dp"
+                        android:layout_marginTop="30dp"
                         android:layout_marginEnd="20dp"
                         android:backgroundTint="@color/white"
                         app:cardCornerRadius="10dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="agent_welcome_message">안녕하세요! 복막투석 AI 상담사입니다. \n투석 관리, 일반 지침, 건강 상태 등에 대해 \n무엇이든 물어보세요.</string>
     <string name="no_weight_data">체중 기록이 없습니다.</string>
     <string name="no_uf_data">제수량 기록이 없습니다.</string>
+    <string name="password_info">•  최소 8자 이상\n•  숫자 포함\n•  특수문자 포함 권장</string>
+    <string name="security_tip">•  정기적으로 비밀번호를 변경하세요\n•  개인 정보가 포함된 비밀번호는 피하세요\n•  비밀번호를 타인과 공유하지 마세요</string>
 </resources>


### PR DESCRIPTION
## 📝 작업 내용
마이페이지에서의 비밀번호 재설정 화면 제작 및 api 연동
현재 비밀번호 + 새 비밀번호 + 새 비밀번호 확인 모두 입력받아야 하며, 조건 처리에 따라 하단에 에러 문구를 표시합니다.

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 비밀번호 변경 기능 추가 — 설정에서 새 비밀번호 입력 후 변경 가능
  * 설정 화면에서 비밀번호 변경 페이지로 이동하는 네비게이션 추가
  * 현재/새 비밀번호 입력란의 가시성 토글(눈 아이콘) 추가
  * 입력 검증·실시간 오류 피드백 및 변경 성공 시 토스트 표시와 이전 화면 복귀 지원
  * 화면 레이아웃의 간격 조정으로 UI 정렬 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->