### PR TITLE
[REFACTOR/#83] 오늘 이후의 날짜 선택 불가

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordEditFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordEditFragment.kt
@@ -714,11 +714,16 @@ class RecordEditFragment : Fragment() {
                 tv.background = null
 
                 val isThisMonth = day.position == DayPosition.MonthDate
+                val isFuture = day.date.isAfter(today)
 
                 tv.setTextColor(
                     ContextCompat.getColor(
                         requireContext(),
-                        if (isThisMonth) R.color.text_primary else R.color.deactive
+                        when {
+                            !isThisMonth -> R.color.deactive // 다른 달
+                            isFuture     -> R.color.deactive // 이번 달이지만 미래 날짜
+                            else         -> R.color.text_primary
+                        }
                     )
                 )
 
@@ -734,20 +739,20 @@ class RecordEditFragment : Fragment() {
                 }
 
                 // 선택된 날짜 표시
-                if (day.date == dialogSelectedDate && isThisMonth) {
-                    tv.setTextColor(
-                        ContextCompat.getColor(
-                            requireContext(),
-                            android.R.color.white
-                        )
-                    )
-                    tv.background =
-                        circleFill(ContextCompat.getColor(requireContext(), R.color.main_1))
+                if (day.date == dialogSelectedDate && isThisMonth && !isFuture) {
+                    tv.setTextColor(ContextCompat.getColor(requireContext(), android.R.color.white))
+                    tv.background = circleFill(ContextCompat.getColor(requireContext(), R.color.main_1))
                 }
 
                 // 날짜 클릭 처리
                 container.view.setOnClickListener {
                     if (!isThisMonth) return@setOnClickListener
+
+                    // 미래 날짜인지 확인
+                    if (day.date.isAfter(today)) {
+                        Toast.makeText(requireContext(), "아직 기록할 수 없는 날짜입니다.", Toast.LENGTH_SHORT).show()
+                        return@setOnClickListener
+                    }
 
                     val hasRecord = eventDates.contains(day.date)
                     val isCurrentRecordDate = currentRecord?.recordDate == day.date

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite01Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite01Fragment.kt
@@ -242,10 +242,16 @@ class RecordWrite01Fragment : Fragment() {
                 tv.background = null
 
                 val isThisMonth = day.position == DayPosition.MonthDate
+                val isFuture = day.date.isAfter(today)
+
                 tv.setTextColor(
                     ContextCompat.getColor(
                         requireContext(),
-                        if (isThisMonth) R.color.text_primary else R.color.deactive
+                        when {
+                            !isThisMonth -> R.color.deactive // 다른 달
+                            isFuture     -> R.color.deactive // 이번 달이지만 미래 날짜
+                            else         -> R.color.text_primary
+                        }
                     )
                 )
 
@@ -261,7 +267,7 @@ class RecordWrite01Fragment : Fragment() {
                 }
 
                 // 날짜 선택
-                if (day.date == dialogSelectedDate && isThisMonth) {
+                if (day.date == dialogSelectedDate && isThisMonth && !isFuture) {
                     tv.setTextColor(ContextCompat.getColor(requireContext(), android.R.color.white))
                     tv.background =
                         circleFill(ContextCompat.getColor(requireContext(), R.color.main_1))
@@ -270,6 +276,12 @@ class RecordWrite01Fragment : Fragment() {
                 // 클릭으로 선택 처리
                 container.view.setOnClickListener {
                     if (!isThisMonth) return@setOnClickListener
+
+                    // 미래 날짜인지 확인
+                    if (day.date.isAfter(today)) {
+                        Toast.makeText(requireContext(), "아직 기록할 수 없는 날짜입니다.", Toast.LENGTH_SHORT).show()
+                        return@setOnClickListener
+                    }
 
                     // 이미 기록이 존재하는 날짜인지 확인
                     val hasRecord = eventDates.contains(day.date)


### PR DESCRIPTION
## 📝 작업 내용
캘린더에서 날짜 선택 시 오늘 이후, 즉 미래의 날짜 선택 불가

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 달력에서 미래 날짜 선택 방지 기능 추가
  * 미래 날짜를 클릭할 때 안내 메시지("아직 기록할 수 없는 날짜입니다.") 표시
  * 미래 날짜 시각적 비활성화 처리로 사용 가능 상태 명확화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->