### PR TITLE
[Feat/#93] FCM 알림 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.hilt.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.parcelize)
+    id("com.google.gms.google-services")
 }
 
 val properties = Properties().apply {
@@ -98,4 +99,8 @@ dependencies {
 
     // PhotoView
     implementation("com.github.chrisbanes:PhotoView:2.2.0")
+
+    // Firebase
+    implementation(platform("com.google.firebase:firebase-bom:34.6.0"))
+    implementation("com.google.firebase:firebase-messaging")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
         android:name=".application.AidiApplication"
         android:allowBackup="true"
@@ -39,6 +41,14 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+
+        <service
+            android:name=".firebase.MomolabFirebaseService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
 
         <activity
             android:name=".ui.splash.SplashActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,10 @@
             </intent-filter>
         </service>
 
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="momolab_morning_channel" />
+
         <activity
             android:name=".ui.splash.SplashActivity"
             android:exported="true">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,7 +43,7 @@
         </provider>
 
         <service
-            android:name=".firebase.MomolabFirebaseService"
+            android:name=".firebase.AidiFirebaseService"
             android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />

--- a/app/src/main/java/com/example/momolabfe/application/AidiApplication.kt
+++ b/app/src/main/java/com/example/momolabfe/application/AidiApplication.kt
@@ -1,6 +1,10 @@
 package com.example.momolabfe.application
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
@@ -8,5 +12,27 @@ class AidiApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        createNotificationChannel()
+    }
+
+    private fun createNotificationChannel() {
+        // 오레오 이상에서만 채널 필요
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channelId = "momolab_morning_channel"
+            val channelName = "아침 투석 알림"
+            val descriptionText = "MOMOLAB AIDI의 아침 투석 계획 알림 채널입니다."
+
+            val importance = NotificationManager.IMPORTANCE_HIGH // 헤드업 알림용
+            val channel = NotificationChannel(channelId, channelName, importance).apply {
+                description = descriptionText
+                enableVibration(true) // 진동
+                enableLights(true) // LED (지원 단말)
+                setShowBadge(true)
+            }
+
+            val notificationManager: NotificationManager =
+                getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
     }
 }

--- a/app/src/main/java/com/example/momolabfe/firebase/AidiFirebaseService.kt
+++ b/app/src/main/java/com/example/momolabfe/firebase/AidiFirebaseService.kt
@@ -1,18 +1,22 @@
 package com.example.momolabfe.firebase
 
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.example.momolabfe.BuildConfig
 import com.example.momolabfe.R
 import com.example.momolabfe.remote.fcm.repository.FcmRepository
+import com.example.momolabfe.ui.main.MainActivity
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -20,6 +24,13 @@ class AidiFirebaseService : FirebaseMessagingService() {
 
     @Inject
     lateinit var fcmRepository: FcmRepository
+
+    private val notificationIdCounter = AtomicInteger(0)
+
+    companion object {
+        private const val FCM_PREFS_NAME = "fcm_prefs"
+        private const val FCM_TOKEN_KEY = "fcm_token"
+    }
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
@@ -57,19 +68,32 @@ class AidiFirebaseService : FirebaseMessagingService() {
     private fun showNotification(title: String, body: String) {
         val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
+        // 앱을 여는 PendingIntent 생성
+        val intent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
         val notification = NotificationCompat.Builder(this, "momolab_morning_channel")
             .setSmallIcon(R.drawable.ic_notification)
             .setContentTitle(title)
             .setContentText(body)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
             .build()
 
-        notificationManager.notify(System.currentTimeMillis().toInt(), notification)
+        // 고유한 알림 ID 사용
+        notificationManager.notify(notificationIdCounter.incrementAndGet(), notification)
     }
 
     private fun saveFcmTokenLocal(token: String) {
-        val prefs = getSharedPreferences("fcm_prefs", MODE_PRIVATE)
-        prefs.edit().putString("fcm_token", token).apply()
+        val prefs = getSharedPreferences(FCM_PREFS_NAME, MODE_PRIVATE)
+        prefs.edit().putString(FCM_TOKEN_KEY, token).apply()
     }
 }

--- a/app/src/main/java/com/example/momolabfe/firebase/AidiFirebaseService.kt
+++ b/app/src/main/java/com/example/momolabfe/firebase/AidiFirebaseService.kt
@@ -1,9 +1,7 @@
 package com.example.momolabfe.firebase
 
 import android.util.Log
-import com.example.momolabfe.remote.fcm.model.FcmTokenRequest
 import com.example.momolabfe.remote.fcm.repository.FcmRepository
-import com.example.momolabfe.remote.fcm.service.FcmService
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/com/example/momolabfe/firebase/AidiFirebaseService.kt
+++ b/app/src/main/java/com/example/momolabfe/firebase/AidiFirebaseService.kt
@@ -4,6 +4,7 @@ import android.app.NotificationManager
 import android.content.Context
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import com.example.momolabfe.BuildConfig
 import com.example.momolabfe.R
 import com.example.momolabfe.remote.fcm.repository.FcmRepository
 import com.google.firebase.messaging.FirebaseMessagingService
@@ -22,7 +23,9 @@ class AidiFirebaseService : FirebaseMessagingService() {
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
-        Log.d("FCM", "새 FCM 토큰: $token")
+        if (BuildConfig.DEBUG) {
+            Log.d("FCM", "새 FCM 토큰(앞 10자리): ${token.take(10)}...")
+        }
 
         // 로컬에 저장
         saveFcmTokenLocal(token)

--- a/app/src/main/java/com/example/momolabfe/firebase/AidiFirebaseService.kt
+++ b/app/src/main/java/com/example/momolabfe/firebase/AidiFirebaseService.kt
@@ -5,13 +5,10 @@ import com.example.momolabfe.remote.fcm.repository.FcmRepository
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class MomolabFirebaseService : FirebaseMessagingService() {
+class AidiFirebaseService : FirebaseMessagingService() {
 
     @Inject
     lateinit var fcmRepository: FcmRepository
@@ -22,13 +19,6 @@ class MomolabFirebaseService : FirebaseMessagingService() {
 
         // 로컬에 저장
         saveFcmTokenLocal(token)
-
-        // 서버에 등록
-        CoroutineScope(Dispatchers.IO).launch {
-            fcmRepository.registerFcmToken(token)
-                .onSuccess { Log.d("FCM", "서버에 FCM 토큰 등록 성공") }
-                .onFailure { e -> Log.e("FCM", "서버에 FCM 토큰 등록 실패", e) }
-        }
     }
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {

--- a/app/src/main/java/com/example/momolabfe/firebase/AidiFirebaseService.kt
+++ b/app/src/main/java/com/example/momolabfe/firebase/AidiFirebaseService.kt
@@ -1,10 +1,17 @@
 package com.example.momolabfe.firebase
 
+import android.app.NotificationManager
+import android.content.Context
 import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.example.momolabfe.R
 import com.example.momolabfe.remote.fcm.repository.FcmRepository
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -19,6 +26,15 @@ class AidiFirebaseService : FirebaseMessagingService() {
 
         // 로컬에 저장
         saveFcmTokenLocal(token)
+
+        // 서버에 등록 (비동기)
+        CoroutineScope(Dispatchers.IO).launch {
+            fcmRepository.registerFcmToken(token).onSuccess {
+                Log.d("FCM", "서버에 토큰 등록 성공")
+            }.onFailure { e ->
+                Log.e("FCM", "서버에 토큰 등록 실패", e)
+            }
+        }
     }
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
@@ -29,7 +45,24 @@ class AidiFirebaseService : FirebaseMessagingService() {
             val title = it.title ?: "MOMOLAB"
             val body = it.body ?: ""
             Log.d("FCM", "알림 수신 title=$title, body=$body")
+
+            // 알림 표시
+            showNotification(title, body)
         }
+    }
+
+    private fun showNotification(title: String, body: String) {
+        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        val notification = NotificationCompat.Builder(this, "momolab_morning_channel")
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .build()
+
+        notificationManager.notify(System.currentTimeMillis().toInt(), notification)
     }
 
     private fun saveFcmTokenLocal(token: String) {

--- a/app/src/main/java/com/example/momolabfe/firebase/MomolabFirebaseService.kt
+++ b/app/src/main/java/com/example/momolabfe/firebase/MomolabFirebaseService.kt
@@ -1,0 +1,51 @@
+package com.example.momolabfe.firebase
+
+import android.util.Log
+import com.example.momolabfe.remote.fcm.model.FcmTokenRequest
+import com.example.momolabfe.remote.fcm.repository.FcmRepository
+import com.example.momolabfe.remote.fcm.service.FcmService
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class MomolabFirebaseService : FirebaseMessagingService() {
+
+    @Inject
+    lateinit var fcmRepository: FcmRepository
+
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+        Log.d("FCM", "새 FCM 토큰: $token")
+
+        // 로컬에 저장
+        saveFcmTokenLocal(token)
+
+        // 서버에 등록
+        CoroutineScope(Dispatchers.IO).launch {
+            fcmRepository.registerFcmToken(token)
+                .onSuccess { Log.d("FCM", "서버에 FCM 토큰 등록 성공") }
+                .onFailure { e -> Log.e("FCM", "서버에 FCM 토큰 등록 실패", e) }
+        }
+    }
+
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        super.onMessageReceived(remoteMessage)
+        Log.d("FCM", "푸시 수신 from=${remoteMessage.from}")
+
+        remoteMessage.notification?.let {
+            val title = it.title ?: "MOMOLAB"
+            val body = it.body ?: ""
+            Log.d("FCM", "알림 수신 title=$title, body=$body")
+        }
+    }
+
+    private fun saveFcmTokenLocal(token: String) {
+        val prefs = getSharedPreferences("fcm_prefs", MODE_PRIVATE)
+        prefs.edit().putString("fcm_token", token).apply()
+    }
+}

--- a/app/src/main/java/com/example/momolabfe/remote/auth/LogoutManager.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/auth/LogoutManager.kt
@@ -1,9 +1,12 @@
 package com.example.momolabfe.remote.auth
 
+import android.content.Context
 import android.util.Log
 import com.example.momolabfe.remote.auth.service.AuthService
+import com.example.momolabfe.remote.fcm.repository.FcmRepository
 import com.example.momolabfe.utils.AuthRetrofit
 import com.example.momolabfe.utils.TokenManager
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -21,7 +24,9 @@ import javax.inject.Singleton
 @Singleton
 class LogoutManager @Inject constructor(
     private val tokenManager: TokenManager,
-    @AuthRetrofit private val retrofitProvider: Provider<Retrofit>, // AuthRetrofit Qualifier가 있다고 가정
+    @AuthRetrofit private val retrofitProvider: Provider<Retrofit>,
+    private val fcmRepository: FcmRepository,
+    @ApplicationContext private val context: Context,
 ) {
     // 로그아웃 성공 이벤트를 발행하는 SharedFlow
     private val _logoutSuccess = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
@@ -50,6 +55,9 @@ class LogoutManager @Inject constructor(
         Log.d("LogoutManager", "로그아웃 시작")
 
         try {
+            val fcmToken = getLocalFcmToken()
+            Log.d("LogoutManager", "로컬 FCM 토큰: $fcmToken")
+
             // 1) 서버 로그아웃 (실패해도 로컬 정리는 진행)
             runCatching {
                 val resp = withContext(Dispatchers.IO) { authService.logout() }
@@ -68,13 +76,24 @@ class LogoutManager @Inject constructor(
                 Log.e("LogoutManager", "서버 로그아웃 호출 중 예외 발생", e)
             }
 
-            // 2) 로컬 정리 (토큰 삭제)
+            // 2) FCM 토큰 비활성화
+            if (!fcmToken.isNullOrBlank()) {
+                withContext(Dispatchers.IO) {
+                    fcmRepository.deactivateFcmToken(fcmToken)
+                        .onSuccess { Log.d("LogoutManager", "FCM 토큰 비활성화 성공") }
+                        .onFailure { e -> Log.e("LogoutManager", "FCM 토큰 비활성화 실패", e) }
+                }
+            } else {
+                Log.d("LogoutManager", "비활성화할 FCM 토큰이 없습니다.")
+            }
+
+            // 3) 로컬 정리 (토큰 삭제)
             withContext(Dispatchers.IO) {
                 tokenManager.clearTokens()
                 Log.d("LogoutManager", "로컬 토큰 정리 완료")
             }
 
-            // 3) UI에 로그아웃 이벤트 발행 (MainActivity가 이를 수신)
+            // 4) UI에 로그아웃 이벤트 발행
             _logoutSuccess.tryEmit(Unit)
 
         } catch (e: Exception) {
@@ -83,4 +102,18 @@ class LogoutManager @Inject constructor(
             loggingOut.set(false)
         }
     }
+
+
+    // FCM 토큰 가져오기
+    private fun getLocalFcmToken(): String? {
+        val prefs = context.getSharedPreferences("fcm_prefs", Context.MODE_PRIVATE)
+        return prefs.getString("fcm_token", null)
+    }
+
+    // FCM 토큰 지우기
+    private fun clearLocalFcmToken() {
+        val prefs = context.getSharedPreferences("fcm_prefs", Context.MODE_PRIVATE)
+        prefs.edit().remove("fcm_token").apply()
+    }
+
 }

--- a/app/src/main/java/com/example/momolabfe/remote/auth/LogoutManager.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/auth/LogoutManager.kt
@@ -1,12 +1,9 @@
 package com.example.momolabfe.remote.auth
 
-import android.content.Context
 import android.util.Log
 import com.example.momolabfe.remote.auth.service.AuthService
-import com.example.momolabfe.remote.fcm.repository.FcmRepository
 import com.example.momolabfe.utils.AuthRetrofit
 import com.example.momolabfe.utils.TokenManager
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -24,9 +21,7 @@ import javax.inject.Singleton
 @Singleton
 class LogoutManager @Inject constructor(
     private val tokenManager: TokenManager,
-    @AuthRetrofit private val retrofitProvider: Provider<Retrofit>,
-    private val fcmRepository: FcmRepository,
-    @ApplicationContext private val context: Context,
+    @AuthRetrofit private val retrofitProvider: Provider<Retrofit>
 ) {
     // 로그아웃 성공 이벤트를 발행하는 SharedFlow
     private val _logoutSuccess = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
@@ -55,16 +50,13 @@ class LogoutManager @Inject constructor(
         Log.d("LogoutManager", "로그아웃 시작")
 
         try {
-            val fcmToken = getLocalFcmToken()
-            Log.d("LogoutManager", "로컬 FCM 토큰: $fcmToken")
-
             // 1) 서버 로그아웃 (실패해도 로컬 정리는 진행)
             runCatching {
                 val resp = withContext(Dispatchers.IO) { authService.logout() }
                 val body = resp.body()
 
-                // 서버 응답이 성공이거나, 이미 로그아웃된 상태(예: AUTH2004)로 처리
-                val ok = resp.isSuccessful && (body?.isSuccess == true || body?.code == "AUTH2004")
+                // 서버 응답이 성공이거나, 이미 로그아웃된 상태로 처리
+                val ok = resp.isSuccessful && (body?.isSuccess == true)
 
                 if (ok) {
                     Log.d("LogoutManager", "서버 로그아웃 성공")
@@ -76,18 +68,7 @@ class LogoutManager @Inject constructor(
                 Log.e("LogoutManager", "서버 로그아웃 호출 중 예외 발생", e)
             }
 
-            // 2) FCM 토큰 비활성화
-            if (!fcmToken.isNullOrBlank()) {
-                withContext(Dispatchers.IO) {
-                    fcmRepository.deactivateFcmToken(fcmToken)
-                        .onSuccess { Log.d("LogoutManager", "FCM 토큰 비활성화 성공") }
-                        .onFailure { e -> Log.e("LogoutManager", "FCM 토큰 비활성화 실패", e) }
-                }
-            } else {
-                Log.d("LogoutManager", "비활성화할 FCM 토큰이 없습니다.")
-            }
-
-            // 3) 로컬 정리 (토큰 삭제)
+            // 2) 로컬 정리 (토큰 삭제)
             withContext(Dispatchers.IO) {
                 tokenManager.clearTokens()
                 Log.d("LogoutManager", "로컬 토큰 정리 완료")
@@ -102,18 +83,4 @@ class LogoutManager @Inject constructor(
             loggingOut.set(false)
         }
     }
-
-
-    // FCM 토큰 가져오기
-    private fun getLocalFcmToken(): String? {
-        val prefs = context.getSharedPreferences("fcm_prefs", Context.MODE_PRIVATE)
-        return prefs.getString("fcm_token", null)
-    }
-
-    // FCM 토큰 지우기
-    private fun clearLocalFcmToken() {
-        val prefs = context.getSharedPreferences("fcm_prefs", Context.MODE_PRIVATE)
-        prefs.edit().remove("fcm_token").apply()
-    }
-
 }

--- a/app/src/main/java/com/example/momolabfe/remote/fcm/model/FcmTokenRequest.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/fcm/model/FcmTokenRequest.kt
@@ -1,0 +1,7 @@
+package com.example.momolabfe.remote.fcm.model
+
+import com.google.gson.annotations.SerializedName
+
+data class FcmTokenRequest(
+    @SerializedName("fcmToken") val fcmToken: String
+)

--- a/app/src/main/java/com/example/momolabfe/remote/fcm/repository/FcmRepository.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/fcm/repository/FcmRepository.kt
@@ -1,6 +1,5 @@
 package com.example.momolabfe.remote.fcm.repository
 
-import android.util.Log
 import com.example.momolabfe.remote.fcm.model.FcmTokenRequest
 import com.example.momolabfe.remote.fcm.service.FcmService
 import javax.inject.Inject
@@ -11,32 +10,20 @@ class FcmRepository @Inject constructor(
     private val fcmService: FcmService,
 ) {
 
-    // 로그인/앱 실행 시 디바이스에서 받은 FCM 토큰을 서버에 등록
-    suspend fun registerFcmToken(token: String): Result<Unit> = runCatching {
-        val request = FcmTokenRequest(fcmToken = token)
-
-        val response = fcmService.registerToken(request)
-        Log.d("FcmRepository", "FCM 토큰 등록 API 호출 코드: ${response.code()}")
-
+    private suspend fun callFcmApi(
+        call: suspend () -> retrofit2.Response<Unit>,
+        failMessage: String
+    ): Result<Unit> = runCatching {
+        val response = call()
         if (!response.isSuccessful) {
-            val errorBody = response.errorBody()?.string()
-            throw RuntimeException("FCM 토큰 등록 실패: code=${response.code()}, body=$errorBody")
+            throw RuntimeException("$failMessage: code=${response.code()}")
         }
-
         Unit
     }
 
-    // 로그아웃 시 서버에 해당 FCM 토큰 비활성화 요청
-    suspend fun deactivateFcmToken(token: String): Result<Unit> = runCatching {
-        val request = FcmTokenRequest(fcmToken = token)
+    suspend fun registerFcmToken(token: String): Result<Unit> =
+        callFcmApi({ fcmService.registerToken(FcmTokenRequest(fcmToken = token)) }, "FCM 토큰 등록 실패")
 
-        val response = fcmService.deactivateToken(request)
-        Log.d("FcmRepository", "FCM 토큰 비활성화 API 호출 코드: ${response.code()}")
-
-        if (!response.isSuccessful) {
-            throw RuntimeException("FCM 토큰 비활성화 실패: code=${response.code()}")
-        }
-
-        Unit
-    }
+    suspend fun deactivateFcmToken(token: String): Result<Unit> =
+        callFcmApi({ fcmService.deactivateToken(FcmTokenRequest(fcmToken = token)) }, "FCM 토큰 비활성화 실패")
 }

--- a/app/src/main/java/com/example/momolabfe/remote/fcm/repository/FcmRepository.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/fcm/repository/FcmRepository.kt
@@ -19,7 +19,11 @@ class FcmRepository @Inject constructor(
         val response = fcmService.registerToken(request)
         Log.d("FcmRepository", "FCM 토큰 등록 API 호출 코드: ${response.code()}")
 
-        handleApiResponseUnit(response)
+        if (!response.isSuccessful) {
+            throw RuntimeException("FCM 토큰 등록 실패: code=${response.code()}")
+        }
+
+        Unit
     }
 
     // 로그아웃 시 서버에 해당 FCM 토큰 비활성화 요청
@@ -29,6 +33,10 @@ class FcmRepository @Inject constructor(
         val response = fcmService.deactivateToken(request)
         Log.d("FcmRepository", "FCM 토큰 비활성화 API 호출 코드: ${response.code()}")
 
-        handleApiResponseUnit(response)
+        if (!response.isSuccessful) {
+            throw RuntimeException("FCM 토큰 비활성화 실패: code=${response.code()}")
+        }
+
+        Unit
     }
 }

--- a/app/src/main/java/com/example/momolabfe/remote/fcm/repository/FcmRepository.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/fcm/repository/FcmRepository.kt
@@ -3,7 +3,6 @@ package com.example.momolabfe.remote.fcm.repository
 import android.util.Log
 import com.example.momolabfe.remote.fcm.model.FcmTokenRequest
 import com.example.momolabfe.remote.fcm.service.FcmService
-import com.example.momolabfe.utils.handleApiResponseUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -20,7 +19,8 @@ class FcmRepository @Inject constructor(
         Log.d("FcmRepository", "FCM 토큰 등록 API 호출 코드: ${response.code()}")
 
         if (!response.isSuccessful) {
-            throw RuntimeException("FCM 토큰 등록 실패: code=${response.code()}")
+            val errorBody = response.errorBody()?.string()
+            throw RuntimeException("FCM 토큰 등록 실패: code=${response.code()}, body=$errorBody")
         }
 
         Unit

--- a/app/src/main/java/com/example/momolabfe/remote/fcm/repository/FcmRepository.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/fcm/repository/FcmRepository.kt
@@ -1,0 +1,34 @@
+package com.example.momolabfe.remote.fcm.repository
+
+import android.util.Log
+import com.example.momolabfe.remote.fcm.model.FcmTokenRequest
+import com.example.momolabfe.remote.fcm.service.FcmService
+import com.example.momolabfe.utils.handleApiResponseUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FcmRepository @Inject constructor(
+    private val fcmService: FcmService,
+) {
+
+    // 로그인/앱 실행 시 디바이스에서 받은 FCM 토큰을 서버에 등록
+    suspend fun registerFcmToken(token: String): Result<Unit> = runCatching {
+        val request = FcmTokenRequest(fcmToken = token)
+
+        val response = fcmService.registerToken(request)
+        Log.d("FcmRepository", "FCM 토큰 등록 API 호출 코드: ${response.code()}")
+
+        handleApiResponseUnit(response)
+    }
+
+    // 로그아웃 시 서버에 해당 FCM 토큰 비활성화 요청
+    suspend fun deactivateFcmToken(token: String): Result<Unit> = runCatching {
+        val request = FcmTokenRequest(fcmToken = token)
+
+        val response = fcmService.deactivateToken(request)
+        Log.d("FcmRepository", "FCM 토큰 비활성화 API 호출 코드: ${response.code()}")
+
+        handleApiResponseUnit(response)
+    }
+}

--- a/app/src/main/java/com/example/momolabfe/remote/fcm/service/FcmService.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/fcm/service/FcmService.kt
@@ -12,10 +12,10 @@ import retrofit2.http.POST
 
 interface FcmService {
     @POST("/api/v1/fcm/token")
-    suspend fun registerToken(@Body request: FcmTokenRequest): Response<ApiResponse<Unit>>
+    suspend fun registerToken(@Body request: FcmTokenRequest): Response<Unit>
 
     @PATCH("/api/v1/fcm/token")
-    suspend fun deactivateToken(@Body request: FcmTokenRequest): Response<ApiResponse<Unit>>
+    suspend fun deactivateToken(@Body request: FcmTokenRequest): Response<Unit>
 
     companion object {
         val instance: FcmService by lazy {

--- a/app/src/main/java/com/example/momolabfe/remote/fcm/service/FcmService.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/fcm/service/FcmService.kt
@@ -1,0 +1,29 @@
+package com.example.momolabfe.remote.fcm.service
+
+import com.example.momolabfe.BuildConfig
+import com.example.momolabfe.remote.fcm.model.FcmTokenRequest
+import com.example.momolabfe.utils.ApiResponse
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.Body
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+
+interface FcmService {
+    @POST("/api/v1/fcm/token")
+    suspend fun registerToken(@Body request: FcmTokenRequest): Response<ApiResponse<Unit>>
+
+    @PATCH("/api/v1/fcm/token")
+    suspend fun deactivateToken(@Body request: FcmTokenRequest): Response<ApiResponse<Unit>>
+
+    companion object {
+        val instance: FcmService by lazy {
+            Retrofit.Builder()
+                .baseUrl(BuildConfig.BASE_URL_SPRING)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+                .create(FcmService::class.java)
+        }
+    }
+}

--- a/app/src/main/java/com/example/momolabfe/remote/fcm/service/FcmService.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/fcm/service/FcmService.kt
@@ -1,11 +1,7 @@
 package com.example.momolabfe.remote.fcm.service
 
-import com.example.momolabfe.BuildConfig
 import com.example.momolabfe.remote.fcm.model.FcmTokenRequest
-import com.example.momolabfe.utils.ApiResponse
 import retrofit2.Response
-import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.Body
 import retrofit2.http.PATCH
 import retrofit2.http.POST
@@ -16,14 +12,4 @@ interface FcmService {
 
     @PATCH("/api/v1/fcm/token")
     suspend fun deactivateToken(@Body request: FcmTokenRequest): Response<Unit>
-
-    companion object {
-        val instance: FcmService by lazy {
-            Retrofit.Builder()
-                .baseUrl(BuildConfig.BASE_URL_SPRING)
-                .addConverterFactory(GsonConverterFactory.create())
-                .build()
-                .create(FcmService::class.java)
-        }
-    }
 }

--- a/app/src/main/java/com/example/momolabfe/ui/auth/viewModel/AuthViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/auth/viewModel/AuthViewModel.kt
@@ -1,5 +1,7 @@
 package com.example.momolabfe.ui.auth.viewModel
 
+import android.content.Context
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -8,8 +10,10 @@ import com.example.momolabfe.remote.auth.model.LoginRequest
 import com.example.momolabfe.remote.auth.model.TokenResponse
 import com.example.momolabfe.remote.auth.repository.AuthRepository
 import com.example.momolabfe.remote.auth.repository.PreferenceRepository
+import com.example.momolabfe.remote.fcm.repository.FcmRepository
 import com.example.momolabfe.utils.TokenManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -20,7 +24,9 @@ import javax.inject.Inject
 class AuthViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val tokenManager: TokenManager,
-    private val prefRepository: PreferenceRepository
+    private val prefRepository: PreferenceRepository,
+    private val fcmRepository: FcmRepository,
+    @ApplicationContext private val appContext: Context
 ) : ViewModel() {
 
     private val _errorMessage = MutableLiveData<String?>()
@@ -33,7 +39,12 @@ class AuthViewModel @Inject constructor(
         viewModelScope.launch {
             val result = authRepository.login(request)
             result.onSuccess { loginResponse ->
+                // 1) 토큰 저장 (→ AuthInterceptor에서 Authorization 헤더 붙일 수 있게)
                 saveTokens(loginResponse.tokens)
+
+                // 2) 로그인 성공 후 FCM 토큰 서버에 등록
+                registerFcmTokenAfterLogin()
+
                 _loginSuccess.tryEmit(Unit)
                 _errorMessage.value = null
             }.onFailure { e ->
@@ -49,6 +60,26 @@ class AuthViewModel @Inject constructor(
         )
     }
 
+    // 로그인 성공 직후, 로컬에 저장된 FCM 토큰을 서버에 등록
+    private suspend fun registerFcmTokenAfterLogin() {
+        val prefs = appContext.getSharedPreferences("fcm_prefs", Context.MODE_PRIVATE)
+        val fcmToken = prefs.getString("fcm_token", null)
+
+        if (fcmToken.isNullOrBlank()) {
+            Log.d("FCM", "저장된 FCM 토큰이 없어 서버에 보낼 수 없음")
+            return
+        }
+
+        Log.d("FCM", "로그인 후 서버에 보낼 FCM 토큰: $fcmToken")
+
+        val result = fcmRepository.registerFcmToken(fcmToken)
+
+        result.onSuccess {
+            Log.d("FCM", "로그인 후 FCM 토큰 서버 등록 성공")
+        }.onFailure { e ->
+            Log.e("FCM", "로그인 후 FCM 토큰 서버 등록 실패", e)
+        }
+    }
 
     // ID 저장
     fun savePatientId(id: String) {

--- a/app/src/main/java/com/example/momolabfe/ui/auth/viewModel/AuthViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/auth/viewModel/AuthViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.momolabfe.BuildConfig
 import com.example.momolabfe.remote.auth.model.LoginRequest
 import com.example.momolabfe.remote.auth.model.TokenResponse
 import com.example.momolabfe.remote.auth.repository.AuthRepository
@@ -70,7 +71,9 @@ class AuthViewModel @Inject constructor(
             return
         }
 
-        Log.d("FCM", "로그인 후 서버에 보낼 FCM 토큰: $fcmToken")
+        if (BuildConfig.DEBUG) {
+            Log.d("FCM", "로그인 후 서버에 보낼 FCM 토큰: ${fcmToken.take(10)}...")
+        }
 
         val result = fcmRepository.registerFcmToken(fcmToken)
 

--- a/app/src/main/java/com/example/momolabfe/utils/ApiModule.kt
+++ b/app/src/main/java/com/example/momolabfe/utils/ApiModule.kt
@@ -6,6 +6,7 @@ import com.example.momolabfe.remote.auth.repository.PreferenceRepository
 import com.example.momolabfe.remote.auth.repository.SharedPreferencesRepository
 import com.example.momolabfe.remote.auth.service.AuthService
 import com.example.momolabfe.remote.consult.service.ConsultService
+import com.example.momolabfe.remote.fcm.service.FcmService
 import com.example.momolabfe.remote.stats.service.StatsService
 import com.example.momolabfe.remote.user.service.UserService
 import dagger.Module
@@ -44,6 +45,12 @@ class ApiModule {
     @NoAuthRetrofit
     fun provideNoAuthServiceForInterceptor(@NoAuthRetrofit retrofit: Retrofit): AuthService {
         return retrofit.create(AuthService::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideFcmApi(@AuthRetrofit retrofit: Retrofit): FcmService {
+        return retrofit.create(FcmService::class.java)
     }
 
     @Provides

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,22a2,2 0 0 0 2,-2h-4a2,2 0 0 0 2,2zM18,16v-5
+            a6,6 0 0 0 -5,-5.91V4a1,1 0 0 0 -2,0v1.09A6,6 0 0 0 6,11v5l-2,2v1h16v-1z" />
+</vector>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.hilt.android) apply false
     alias(libs.plugins.ksp) apply false
+    id("com.google.gms.google-services") version "4.4.4" apply false
 }


### PR DESCRIPTION
## 📝 작업 내용
FCM 알림 연동

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Firebase 기반 푸시 알림 통합 — FCM을 통한 푸시 수신 및 표시가 추가되었습니다.
  * 아침 투석 알림 리마인더 — 예정된 투석 시간을 알림으로 받을 수 있습니다.
  * 알림 채널 향상 — 우선순위, 진동·조명·배지 설정이 적용되었습니다.
  * 로그인 후 기기 토큰 등록 및 로컬 저장 — 로그인 시 서버에 푸시 토큰을 등록합니다.

* **버그 수정**
  * 로그아웃 처리 로직 정비 — 로그아웃 응답 처리 방식이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->