### PR TITLE
[Refactor/#94] 기록 수정 화면 작업

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordEditFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordEditFragment.kt
@@ -86,6 +86,7 @@ class RecordEditFragment : Fragment() {
     companion object {
         private val TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm", Locale.KOREA)
         private const val DATE_PATTERN = "yyyy년 M월"
+        private const val MAX_EXCHANGES = 5
     }
 
     override fun onCreateView(
@@ -152,6 +153,10 @@ class RecordEditFragment : Fragment() {
         binding.changeDateBtn.setOnClickListener {
             showCalendarDialogForEdit()
         }
+
+        binding.addExchangeBtn.setOnClickListener {
+            addExchangeRow()
+        }
     }
 
     private fun showError(message: String) {
@@ -162,6 +167,12 @@ class RecordEditFragment : Fragment() {
     private fun clearError() {
         binding.recordErrorTv.text = ""
         binding.recordErrorTv.visibility = View.GONE
+    }
+
+    private fun updateAddExchangeButtonVisibility() {
+        val childCount = binding.exchangeEditContainer.childCount
+        binding.addExchangeBtn.visibility =
+            if (childCount < MAX_EXCHANGES) View.VISIBLE else View.GONE
     }
 
     private fun setupTurbidityCheckboxes() {
@@ -676,6 +687,8 @@ class RecordEditFragment : Fragment() {
 
             container.addView(itemBinding.root)
         }
+
+        updateAddExchangeButtonVisibility()
     }
 
     private fun showCalendarDialogForEdit() {
@@ -896,6 +909,38 @@ class RecordEditFragment : Fragment() {
     private inner class DayViewContainer(view: View) : ViewContainer(view) {
         val textView: TextView = view.findViewById(R.id.calendar_day_tv)
         val dotView: View = view.findViewById(R.id.dot_view)
+    }
+
+    private fun addExchangeRow() {
+        val container = binding.exchangeEditContainer
+        val childCount = container.childCount
+
+        if (childCount >= MAX_EXCHANGES) {
+            Toast.makeText(requireContext(), "회차는 최대 ${MAX_EXCHANGES}회까지만 추가할 수 있습니다.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val inflater = LayoutInflater.from(requireContext())
+        val itemBinding = ItemExchangeEditBinding.inflate(inflater, container, false)
+
+        val index = childCount
+        itemBinding.exchangeTitleTv.text = "${index + 1}회차"
+
+        itemBinding.exchangeTimeValueEt.setText("")
+        itemBinding.drainVolumeValueEt.setText("")
+        itemBinding.fillVolumeValueEt.setText("")
+        itemBinding.fillConcentrationValueEt.setText("")
+        itemBinding.ufValueEt.setText("")
+
+        // 시간 선택 클릭 시 타임피커 열기
+        itemBinding.exchangeTimeValueEt.setOnClickListener {
+            showTimePickerDialogForView(index, itemBinding.exchangeTimeValueEt)
+        }
+
+        container.addView(itemBinding.root)
+
+        // 새로 추가한 뒤 버튼 상태 갱신
+        updateAddExchangeButtonVisibility()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
@@ -234,7 +234,6 @@ class RecordInfoFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        activity?.findViewById<BottomNavigationView>(R.id.main_bnv)?.visibility = View.VISIBLE // 가시성 복원
         _binding = null
     }
 }

--- a/app/src/main/res/layout/fragment_record_edit.xml
+++ b/app/src/main/res/layout/fragment_record_edit.xml
@@ -429,8 +429,7 @@
                 android:layout_marginTop="30dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/common_info_section"
-                app:layout_constraintBottom_toTopOf="@id/bottom_bar">
+                app:layout_constraintTop_toBottomOf="@id/common_info_section">
 
                 <View
                     android:id="@+id/section_indicator_exchange"
@@ -459,6 +458,7 @@
                     android:id="@+id/exchange_edit_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
                     android:orientation="vertical"
                     android:paddingStart="20dp"
                     android:paddingEnd="20dp"
@@ -467,6 +467,26 @@
                     app:layout_constraintEnd_toEndOf="parent" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/add_exchange_btn"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="10dp"
+                android:backgroundTint="@color/white"
+                android:fontFamily="@font/noto_sans_kr_regular"
+                android:text="+  회차 추가"
+                android:textColor="@color/main_1"
+                android:textSize="15sp"
+                app:cornerRadius="12dp"
+                app:strokeWidth="0.5dp"
+                app:strokeColor="@color/main_1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/exchange_info_section" />
 
             <TextView
                 android:id="@+id/record_error_tv"
@@ -480,7 +500,7 @@
                 android:includeFontPadding="false"
                 android:fontFamily="@font/noto_sans_kr_regular"
                 android:visibility="gone"
-                app:layout_constraintTop_toBottomOf="@id/exchange_info_section"
+                app:layout_constraintTop_toBottomOf="@id/add_exchange_btn"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/layout/fragment_record_edit.xml
+++ b/app/src/main/res/layout/fragment_record_edit.xml
@@ -13,7 +13,7 @@
         android:layout_height="match_parent"
         android:clipToPadding="false"
         android:fillViewport="true"
-        android:paddingBottom="40dp">
+        android:paddingBottom="60dp">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
## 📝 작업 내용
- 기록 수정 화면에서 바텀 네비바 숨기기
- 회차별 정보 추가할 수 있는 뷰 생성하기

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 기록 편집 화면에서 교환 항목을 동적으로 추가할 수 있는 기능 추가
  * 최대 5개까지 교환 행 추가 제한
  * 추가 버튼은 한도 도달 시 자동으로 숨겨짐

* **스타일**
  * 기록 편집 화면의 여백 및 레이아웃 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->