### PR TITLE
[BUG/#102] 그래프 간격 조정

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/stats/StatsFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/stats/StatsFragment.kt
@@ -176,11 +176,11 @@ class StatsFragment : Fragment() {
             position = XAxis.XAxisPosition.BOTTOM
             granularity = 1f
             setDrawGridLines(false)
+            setDrawAxisLine(false)
 
-            // 라벨은 항상 7개 강제
             axisMinimum = -0.5f
             axisMaximum = labels.size - 0.5f
-            setLabelCount(labels.size, /*force=*/true)
+            setLabelCount(labels.size, /*force=*/false)
 
             valueFormatter = object : ValueFormatter() {
                 override fun getFormattedValue(value: Float): String {
@@ -274,10 +274,9 @@ class StatsFragment : Fragment() {
             setDrawGridLines(false)
             setDrawAxisLine(false)
 
-            // 라벨은 항상 7개 강제
             axisMinimum = -0.5f
             axisMaximum = labels.size - 0.5f
-            setLabelCount(labels.size, /*force=*/true)
+            setLabelCount(labels.size, /*force=*/false)
 
             valueFormatter = object : ValueFormatter() {
                 override fun getFormattedValue(value: Float): String {


### PR DESCRIPTION
## 📝 작업 내용
날짜 라벨 간격과 그래프 간격이 맞지 않아 날짜 라벨 위치를 그래프의 데이터 값에 맞춤.

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 차트의 X축 축선 표시를 비활성화했습니다.
  * 라벨 개수 강제 제약을 제거하여 더 유연한 라벨 배치를 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->