### PR TITLE
[Refactor/#112] 상담 기록 조회 ui 수정

### DIFF
--- a/app/src/main/java/com/example/momolabfe/remote/consult/model/ConsultResponse.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/consult/model/ConsultResponse.kt
@@ -14,8 +14,7 @@ data class SessionEndResponse (
 
 data class GetConsultResponse (
     @SerializedName("session_id") val sessionId: String,
-    @SerializedName("started_at") val startedAt: String,
-    @SerializedName("message_count") val messageCount: Int,
+    @SerializedName("ended_at") val endedAt: String,
     @SerializedName("first_user_question") val firstUserQuestion: String
 )
 

--- a/app/src/main/java/com/example/momolabfe/ui/consult/ConsultFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/ConsultFragment.kt
@@ -1,28 +1,22 @@
 package com.example.momolabfe.ui.consult
 
 import android.app.Dialog
-import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import android.widget.Toast
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.example.momolabfe.R
 import com.example.momolabfe.databinding.FragmentConsultBinding
 import com.example.momolabfe.remote.consult.model.ChatRequest
 import com.example.momolabfe.remote.consult.model.SessionEndRequest
 import com.example.momolabfe.ui.consult.adapter.ChatAdapter
-import com.example.momolabfe.ui.consult.adapter.ConsultHistoryAdapter
 import com.example.momolabfe.ui.consult.viewModel.ConsultViewModel
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import androidx.core.graphics.drawable.toDrawable
-import com.example.momolabfe.utils.dpToPx
 
 class ConsultFragment : Fragment() {
 
@@ -66,7 +60,10 @@ class ConsultFragment : Fragment() {
         }
 
         binding.historyIv.setOnClickListener {
-            showConsultHistoryDialog()
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.main_frm, ConsultHistoryFragment())
+                .addToBackStack(null)
+                .commit()
         }
 
         binding.sendBtn.setOnClickListener {
@@ -207,70 +204,6 @@ class ConsultFragment : Fragment() {
     private fun showQuickQuestions() {
         binding.quickQuestionLabel.visibility = View.VISIBLE
         binding.quickQuestionGroup.visibility = View.VISIBLE
-    }
-
-    private fun showConsultHistoryDialog() {
-        historyDialog?.dismiss()
-        val dialog = Dialog(requireContext())
-        historyDialog = dialog
-        val inflater = LayoutInflater.from(requireContext())
-        val view = inflater.inflate(R.layout.dialog_consult_history, null)
-
-        dialog.setContentView(view)
-
-        // 배경 둥근 모서리가 잘 보이도록 투명 처리
-        dialog.window?.setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
-        dialog.window?.setLayout(
-            ViewGroup.LayoutParams.MATCH_PARENT,
-            ViewGroup.LayoutParams.WRAP_CONTENT
-        )
-
-        // 닫기 버튼
-        val closeIv = view.findViewById<ImageView>(R.id.close_iv)
-        closeIv.setOnClickListener {
-            dialog.dismiss()
-        }
-
-        val historyRv = view.findViewById<RecyclerView>(R.id.consult_history_rv)
-        val historyAdapter = ConsultHistoryAdapter(
-            onClick = { item ->
-                dialog.dismiss()
-
-                val fragment = ConsultHistoryDetailFragment.newInstance(item.sessionId)
-
-                parentFragmentManager.beginTransaction()
-                    .replace(R.id.main_frm, fragment)
-                    .addToBackStack(null)
-                    .commit()
-            },
-            onDelete = { item ->
-                viewModel.deleteConsult(item.sessionId)
-            }
-        )
-
-        historyRv.apply {
-            layoutManager = LinearLayoutManager(requireContext())
-            adapter = historyAdapter
-            itemAnimator = null
-        }
-
-        viewModel.history.observe(viewLifecycleOwner) { list ->
-            if (dialog.isShowing) {
-                historyAdapter.submitList(list)
-            }
-        }
-
-        viewModel.getConsultList(skip = 0, limit = 50)
-        dialog.show()
-
-        // 양옆 여백 + 높이 설정
-        val metrics = resources.displayMetrics
-        val screenWidth = metrics.widthPixels
-        val horizontalMarginPx = dpToPx(20) * 2
-        val dialogWidth = screenWidth - horizontalMarginPx
-        val dialogHeight = dpToPx(380)
-
-        dialog.window?.setLayout(dialogWidth, dialogHeight)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/momolabfe/ui/consult/ConsultHistoryFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/ConsultHistoryFragment.kt
@@ -1,0 +1,78 @@
+package com.example.momolabfe.ui.consult
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.momolabfe.databinding.FragmentConsultHistoryBinding
+import com.example.momolabfe.ui.consult.adapter.ConsultHistoryAdapter
+import com.example.momolabfe.ui.consult.viewModel.ConsultViewModel
+import com.example.momolabfe.R
+import com.google.android.material.bottomnavigation.BottomNavigationView
+
+class ConsultHistoryFragment : Fragment() {
+
+    private var _binding: FragmentConsultHistoryBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: ConsultViewModel by activityViewModels()
+
+    private val historyAdapter by lazy {
+        ConsultHistoryAdapter(
+            onClick = { item ->
+                val fragment = ConsultHistoryDetailFragment.newInstance(item.sessionId)
+
+                parentFragmentManager.beginTransaction()
+                    .replace(R.id.main_frm, fragment)
+                    .addToBackStack(null)
+                    .commit()
+            },
+            onDelete = { item ->
+                viewModel.deleteConsult(item.sessionId)
+            }
+        )
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentConsultHistoryBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // 바텀 내비게이션 숨기기
+        activity?.findViewById<BottomNavigationView>(R.id.main_bnv)?.visibility = View.GONE
+
+        setupRecyclerView()
+        setupObservers()
+
+        // 서버에서 상담 목록 조회
+        viewModel.getConsultList()
+    }
+
+    private fun setupRecyclerView() {
+        binding.historyRv.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = historyAdapter
+            itemAnimator = null
+        }
+    }
+
+    private fun setupObservers() {
+        viewModel.history.observe(viewLifecycleOwner) { list ->
+            historyAdapter.submitList(list)
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/example/momolabfe/ui/consult/adapter/ConsultHistoryAdapter.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/adapter/ConsultHistoryAdapter.kt
@@ -57,9 +57,7 @@ class ConsultHistoryAdapter(
                 paintFlags = paintFlags or Paint.UNDERLINE_TEXT_FLAG
             }
 
-            binding.dateTv.text = formatStartedAt(item.startedAt)
-
-            binding.messageCountTv.text = "• ${item.messageCount}개 메시지"
+            binding.dateTv.text = formatEndedAt(item.endedAt)
 
             binding.titleTv.setOnClickListener {
                 onClick(item)
@@ -70,14 +68,14 @@ class ConsultHistoryAdapter(
             }
         }
 
-        private fun formatStartedAt(raw: String): String {
+        private fun formatEndedAt(raw: String): String {
             return try {
                 val dt = LocalDateTime.parse(raw, INPUT_FORMATTER)
                 val datePart = dt.format(DATE_FORMATTER)
                 val timePart = dt.format(TIME_FORMATTER)
                 "$datePart\n$timePart"
             } catch (e: Exception) {
-                // 파싱 실패 시 raw 그대로 보여줌 (최소 망가지진 않게)
+                // 파싱 실패 시 raw 그대로 보여줌
                 raw
             }
         }

--- a/app/src/main/res/layout/fragment_consult_history.xml
+++ b/app/src/main/res/layout/fragment_consult_history.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/main_bg"
+    tools:context=".ui.consult.ConsultHistoryFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/title_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="60dp"
+        android:background="@drawable/bg_gradient_indigo"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/robot_iv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="30dp"
+            android:src="@drawable/ic_robot_sv"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/title_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="15dp"
+            android:layout_marginTop="15dp"
+            android:fontFamily="@font/noto_sans_kr_medium"
+            android:includeFontPadding="false"
+            android:text="AI 상담"
+            android:textColor="@color/white"
+            android:textSize="18sp"
+            app:layout_constraintStart_toEndOf="@id/robot_iv"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/sparkle_iv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="3dp"
+            android:layout_marginTop="5dp"
+            android:src="@drawable/ic_sparkle_sv"
+            app:layout_constraintStart_toEndOf="@id/robot_iv"
+            app:layout_constraintTop_toBottomOf="@id/title_tv" />
+
+        <TextView
+            android:id="@+id/content_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="3dp"
+            android:layout_marginBottom="20dp"
+            android:fontFamily="@font/noto_sans_kr_regular"
+            android:includeFontPadding="false"
+            android:text="상담 기록 목록 조회"
+            android:textColor="@color/white"
+            android:textSize="15sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@id/sparkle_iv"
+            app:layout_constraintTop_toTopOf="@id/sparkle_iv" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/history_rv"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="30dp"
+        android:layout_marginStart="15dp"
+        android:layout_marginEnd="15dp"
+        android:layout_marginBottom="60dp"
+        android:overScrollMode="never"
+        app:layout_constraintTop_toBottomOf="@id/title_container"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_consult_history.xml
+++ b/app/src/main/res/layout/fragment_consult_history.xml
@@ -59,7 +59,7 @@
             android:layout_marginBottom="20dp"
             android:fontFamily="@font/noto_sans_kr_regular"
             android:includeFontPadding="false"
-            android:text="상담 기록 목록 조회"
+            android:text="상담 기록 조회"
             android:textColor="@color/white"
             android:textSize="15sp"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/item_consult_history.xml
+++ b/app/src/main/res/layout/item_consult_history.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginTop="10dp"
@@ -18,53 +19,54 @@
             android:id="@+id/title_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
+            android:layout_marginStart="5dp"
             android:layout_marginTop="20dp"
-            android:text="새로운 상담"
+            tools:text="새로운 상담"
             android:textColor="@color/text_primary"
             android:textSize="15sp"
             android:textStyle="bold"
             android:fontFamily="@font/noto_sans_kr_regular"
             android:includeFontPadding="false"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toEndOf="@id/date_iv"
             app:layout_constraintTop_toTopOf="parent"/>
 
         <ImageView
             android:id="@+id/date_iv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
+            android:layout_marginStart="20dp"
             android:src="@drawable/ic_calendar_gray_sv"
-            app:layout_constraintStart_toStartOf="@id/title_tv"
-            app:layout_constraintTop_toBottomOf="@id/title_tv"/>
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/title_tv"/>
 
         <TextView
             android:id="@+id/date_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="5dp"
-            android:layout_marginBottom="20dp"
-            android:text="2025년 11월 19일\n오후 17:22"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="5dp"
+            tools:text="2025년 11월 19일 오후 17:22"
             android:textColor="@color/secondary_text"
             android:textSize="12sp"
             android:fontFamily="@font/noto_sans_kr_regular"
             android:includeFontPadding="false"
-            app:layout_constraintStart_toEndOf="@id/date_iv"
-            app:layout_constraintTop_toTopOf="@id/date_iv"
-            app:layout_constraintBottom_toBottomOf="parent"/>
+            app:layout_constraintEnd_toEndOf="@id/delete_iv"
+            app:layout_constraintTop_toBottomOf="@id/delete_iv"/>
 
         <TextView
-            android:id="@+id/message_count_tv"
+            android:id="@+id/summary_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="50dp"
-            android:text="• 1개 메시지"
+            android:layout_marginTop="30dp"
+            android:layout_marginBottom="20dp"
+            android:text="상담 요약 내용 블라블라"
             android:textColor="@color/secondary_text"
             android:textSize="12sp"
             android:fontFamily="@font/noto_sans_kr_regular"
             android:includeFontPadding="false"
-            app:layout_constraintTop_toTopOf="@id/date_tv"
-            app:layout_constraintEnd_toEndOf="@id/delete_iv"/>
+            app:layout_constraintTop_toBottomOf="@id/date_iv"
+            app:layout_constraintStart_toStartOf="@id/date_iv"
+            app:layout_constraintBottom_toBottomOf="parent"/>
 
         <ImageView
             android:id="@+id/delete_iv"
@@ -72,7 +74,7 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="20dp"
             android:src="@drawable/ic_trash_gray_sv"
-            app:layout_constraintTop_toTopOf="@id/date_tv"
+            app:layout_constraintTop_toTopOf="@id/title_tv"
             app:layout_constraintEnd_toEndOf="parent"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_consult_history.xml
+++ b/app/src/main/res/layout/item_consult_history.xml
@@ -19,54 +19,54 @@
             android:id="@+id/title_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="5dp"
             android:layout_marginTop="20dp"
+            android:layout_marginStart="20dp"
             tools:text="새로운 상담"
             android:textColor="@color/text_primary"
             android:textSize="15sp"
             android:textStyle="bold"
             android:fontFamily="@font/noto_sans_kr_regular"
             android:includeFontPadding="false"
-            app:layout_constraintStart_toEndOf="@id/date_iv"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"/>
 
         <ImageView
             android:id="@+id/date_iv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
             android:layout_marginStart="20dp"
             android:src="@drawable/ic_calendar_gray_sv"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/title_tv"/>
+            app:layout_constraintTop_toBottomOf="@id/summary_tv"/>
 
         <TextView
             android:id="@+id/date_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="10dp"
-            android:layout_marginTop="5dp"
+            android:layout_marginStart="5dp"
+            android:layout_marginBottom="20dp"
             tools:text="2025년 11월 19일 오후 17:22"
             android:textColor="@color/secondary_text"
             android:textSize="12sp"
             android:fontFamily="@font/noto_sans_kr_regular"
             android:includeFontPadding="false"
-            app:layout_constraintEnd_toEndOf="@id/delete_iv"
-            app:layout_constraintTop_toBottomOf="@id/delete_iv"/>
+            app:layout_constraintStart_toEndOf="@id/date_iv"
+            app:layout_constraintTop_toTopOf="@id/date_iv"
+            app:layout_constraintBottom_toBottomOf="parent"/>
 
         <TextView
             android:id="@+id/summary_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="30dp"
-            android:layout_marginBottom="20dp"
             android:text="상담 요약 내용 블라블라"
             android:textColor="@color/secondary_text"
             android:textSize="12sp"
             android:fontFamily="@font/noto_sans_kr_regular"
             android:includeFontPadding="false"
-            app:layout_constraintTop_toBottomOf="@id/date_iv"
-            app:layout_constraintStart_toStartOf="@id/date_iv"
-            app:layout_constraintBottom_toBottomOf="parent"/>
+            app:layout_constraintTop_toBottomOf="@id/title_tv"
+            app:layout_constraintStart_toStartOf="@id/title_tv" />
 
         <ImageView
             android:id="@+id/delete_iv"

--- a/app/src/main/res/layout/item_consult_history.xml
+++ b/app/src/main/res/layout/item_consult_history.xml
@@ -6,7 +6,8 @@
     android:layout_marginTop="10dp"
     android:backgroundTint="@color/white"
     app:cardCornerRadius="10dp"
-    app:cardElevation="0dp">
+    app:cardElevation="0dp"
+    app:strokeWidth="0dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
## 📝 작업 내용
- 기존에는 모달창에서 조회 가능한 형태 -> 별도의 프레그먼트로 제작하여 해당 뷰에서 조회되도록 제작
- api 수정사항 반영: 세션 카드뷰에 제목, 상담 요약 내용, 상담 종료 날짜 반환
- 상담 요약 api는 추후에 구현

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 상담 기록 화면 업데이트

* **새로운 기능**
  * 상담 기록을 위한 전용 화면이 추가되었습니다. 기존 팝업 대신 독립적인 화면에서 상담 기록을 확인할 수 있습니다.

* **사용자 인터페이스 개선**
  * 상담 시작 시간 대신 종료 시간을 표시하도록 변경되었습니다.
  * 메시지 개수 표시가 제거되었습니다.
  * 상담 기록 화면의 레이아웃이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->