### PR TITLE
[BUG/#130] 에이전트 답변 생성 도중 종료 버튼이 생기는 문제

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/consult/ConsultFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/ConsultFragment.kt
@@ -65,8 +65,8 @@ class ConsultFragment : Fragment() {
 
         binding.endIv.visibility = View.GONE
 
-        // 이전 세션의 말풍선/이벤트/에러 모두 정리
-        viewModel.resetMessages()
+        currentSessionId = null // 이전 세션 ID 무효화
+        viewModel.resetMessages() // 말풍선 / 에이전트 버퍼 모두 초기화
         viewModel.clearError()
 
         setupRecyclerView()
@@ -74,10 +74,7 @@ class ConsultFragment : Fragment() {
         showQuickQuestions()
         setupSendButtonState()
 
-        // 처음 진입 시 세션 없으면 상담 세션 생성
-        if (currentSessionId == null) {
-            viewModel.startConsult()
-        }
+        viewModel.startConsult()
 
         binding.historyIv.setOnClickListener {
             parentFragmentManager.beginTransaction()
@@ -186,7 +183,6 @@ class ConsultFragment : Fragment() {
     private fun setupObservers() {
         viewModel.startConsult.observe(viewLifecycleOwner) { response ->
             currentSessionId = response.sessionId
-            viewModel.resetMessages()
             binding.endIv.visibility = View.GONE
         }
 
@@ -213,13 +209,18 @@ class ConsultFragment : Fragment() {
             val hasAgentReplyAfterUser = if (firstUserIndex == -1) {
                 false
             } else {
-                list.drop(firstUserIndex + 1).any { msg ->
-                    !msg.isUser && msg.text.isNotBlank()
-                }
+                list
+                    .drop(firstUserIndex + 1)
+                    .any { msg ->
+                        !msg.isUser &&
+                                msg.text.isNotBlank() &&
+                                !msg.isTyping // 스트리밍 중인 말풍선은 제외
+                    }
             }
 
             val hasActiveSession = !currentSessionId.isNullOrBlank()
-            val shouldShowEndButton = hasActiveSession && hasAgentReplyAfterUser
+            val shouldShowEndButton =
+                hasActiveSession && hasAgentReplyAfterUser && !viewModel.isStreamingNow()
 
             binding.endIv.visibility = if (shouldShowEndButton) View.VISIBLE else View.GONE
 
@@ -233,7 +234,7 @@ class ConsultFragment : Fragment() {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.endConsultSuccess.collect { endedSessionId ->
                     waitingSummaryForSessionId = endedSessionId
-                    viewModel.summaryConsult(endedSessionId)
+                    viewModel.startSummaryFromConsultEnd(endedSessionId)
                 }
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/consult/ConsultHistoryFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/ConsultHistoryFragment.kt
@@ -36,7 +36,7 @@ class ConsultHistoryFragment : Fragment() {
                 showDeleteConfirmDialog(item.sessionId)
             },
             onRetrySummary = { item ->
-                viewModel.summaryConsult(item.sessionId)
+                viewModel.retrySummaryFromHistory(item.sessionId)
                 Toast.makeText(requireContext(), "요약을 다시 생성하고 있어요.", Toast.LENGTH_SHORT).show()
             }
         )

--- a/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
@@ -113,6 +113,7 @@ class ConsultViewModel @Inject constructor(
                 _errorMessage.value = e.localizedMessage ?: "에이전트 대화 중 오류가 발생했습니다."
             } finally {
                 isStreaming = false
+                markAgentMessageCompleted()
             }
         }
     }
@@ -186,28 +187,21 @@ class ConsultViewModel @Inject constructor(
     // 특정 상담 세션 요약
     fun summaryConsult(sessionId: String) {
         viewModelScope.launch {
-            // 요약 시작 상태 세팅
-            _summaryUiState.value = SummaryUiState(
-                isSummarizing = true,
-                targetSessionId = sessionId
-            )
 
             val result = consultRepository.summaryConsult(sessionId)
             result.onSuccess { response ->
                 _summaryResult.value = response
 
                 // 요약 종료 상태로 리셋
-                _summaryUiState.value = SummaryUiState(
-                    isSummarizing = false,
-                    targetSessionId = null
+                _summaryUiState.value = _summaryUiState.value.copy(
+                    isSummarizing = false
                 )
             }.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "특정 상담 세션 요약에 실패했습니다."
 
                 // 실패해도 상태는 종료로 리셋
-                _summaryUiState.value = SummaryUiState(
-                    isSummarizing = false,
-                    targetSessionId = null
+                _summaryUiState.value = _summaryUiState.value.copy(
+                    isSummarizing = false
                 )
             }
         }
@@ -258,7 +252,6 @@ class ConsultViewModel @Inject constructor(
             val last = current.last()
             current[current.lastIndex] = last.copy(
                 text = fullText,
-                isTyping = false
             )
         } else {
             // 에이전트 말풍선이 없으면 새로 하나 생성
@@ -267,7 +260,7 @@ class ConsultViewModel @Inject constructor(
                     id = nextId(),
                     text = fullText,
                     isUser = false,
-                    isTyping = false
+                    isTyping = true
                 )
             )
         }
@@ -283,6 +276,40 @@ class ConsultViewModel @Inject constructor(
         val old = current[index]
         current[index] = old.copy(summary = row.summary)
         _history.value = current
+    }
+
+    // 답변 완료 마킹 함수
+    private fun markAgentMessageCompleted() {
+        val current = _messages.value.orEmpty().toMutableList()
+        if (current.isNotEmpty() && !current.last().isUser) {
+            val last = current.last()
+            if (last.isTyping) {
+                current[current.lastIndex] = last.copy(isTyping = false)
+                _messages.value = current
+            }
+        }
+    }
+
+    // 상담 화면에서 종료 버튼으로 끝냈을 때 호출
+    fun startSummaryFromConsultEnd(sessionId: String) {
+        _summaryUiState.value = SummaryUiState(
+            isSummarizing = true,
+            targetSessionId = sessionId,
+            navigateToHistoryOnEnd = true
+        )
+
+        summaryConsult(sessionId)
+    }
+
+    // 기록 화면에서 "요약 다시 생성" 눌렀을 때 호출
+    fun retrySummaryFromHistory(sessionId: String) {
+        _summaryUiState.value = SummaryUiState(
+            isSummarizing = true,
+            targetSessionId = sessionId,
+            navigateToHistoryOnEnd = false
+        )
+
+        summaryConsult(sessionId)
     }
 
     // 새 상담 시작 시 히스토리 초기화

--- a/app/src/main/res/layout/item_consult_history.xml
+++ b/app/src/main/res/layout/item_consult_history.xml
@@ -76,7 +76,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="30dp"
-            android:text="요약 다시 생성"
+            tools:text="요약 다시 생성"
             android:textColor="@color/secondary_text"
             android:textSize="12sp"
             android:visibility="gone"


### PR DESCRIPTION
## 📝 작업 내용
에이전트가 답변을 생성하는 도중에 종료 버튼이 생겨서, 이를 클릭하면 상담이 종료되는 문제 -> 에이전트가 완전한 답변을 출력해야 종료 버튼 보이도록 수정

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 상담 세션 초기화 및 상태 관리 개선
  * 메시지 표시 로직 및 종료 버튼 가시성 개선
  * 상담 종료 후 요약 요청 흐름 개선
  * 요약 생성 중 타임아웃 처리 시 상태 정리 개선

* **개선 사항**
  * 상담 종료 후 히스토리로의 전환 시 상태 처리 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->