### PR TITLE
[BUG/#130] 상담 진행 도중 히스토리 버튼을 누를 수 있는 문제

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/consult/ConsultFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/ConsultFragment.kt
@@ -77,10 +77,37 @@ class ConsultFragment : Fragment() {
         viewModel.startConsult()
 
         binding.historyIv.setOnClickListener {
-            parentFragmentManager.beginTransaction()
-                .replace(R.id.main_frm, ConsultHistoryFragment())
-                .addToBackStack(null)
-                .commit()
+            val sessionId = currentSessionId
+
+            // 진행 중인 상담 여부 판단
+            val hasConversation = viewModel.messages.value
+                ?.any { msg -> msg.isUser && msg.text.isNotBlank() } == true
+
+            if (!sessionId.isNullOrBlank() && hasConversation) {
+                // 상담이 진행 중인데 히스토리 버튼을 클릭한 경우
+                AlertDialog.Builder(requireContext())
+                    .setTitle("기록 조회")
+                    .setMessage("현재 상담이 종료되지 않았습니다.\n기록을 조회하러 가시겠습니까?")
+                    .setNegativeButton("계속 상담") { dialog, _ ->
+                        dialog.dismiss()
+                    }
+                    .setPositiveButton("기록 조회") { dialog, _ ->
+                        dialog.dismiss()
+                        endSession()
+
+                        parentFragmentManager.beginTransaction()
+                            .replace(R.id.main_frm, ConsultHistoryFragment())
+                            .addToBackStack(null)
+                            .commit()
+                    }
+                    .show()
+            } else {
+                // 진행 중인 상담이 없으면 바로 기록 화면으로 이동
+                parentFragmentManager.beginTransaction()
+                    .replace(R.id.main_frm, ConsultHistoryFragment())
+                    .addToBackStack(null)
+                    .commit()
+            }
         }
 
         binding.endIv.setOnClickListener {

--- a/app/src/main/res/layout/item_consult_history.xml
+++ b/app/src/main/res/layout/item_consult_history.xml
@@ -59,7 +59,7 @@
             android:id="@+id/summary_tv"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="30dp"
+            android:layout_marginTop="20dp"
             tools:text="상담 요약 내용 블라블라"
             android:textColor="@color/secondary_text"
             android:textSize="12sp"
@@ -75,15 +75,16 @@
             android:id="@+id/retry_summary_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="30dp"
-            tools:text="요약 다시 생성"
-            android:textColor="@color/secondary_text"
+            android:layout_marginTop="2dp"
+            android:layout_marginStart="10dp"
+            android:text="@string/retry_summary"
+            android:textColor="@color/main_1"
             android:textSize="12sp"
-            android:visibility="gone"
             android:fontFamily="@font/noto_sans_kr_regular"
             android:includeFontPadding="false"
-            app:layout_constraintTop_toBottomOf="@id/title_tv"
-            app:layout_constraintStart_toStartOf="@id/title_tv"/>
+            android:visibility="gone"
+            app:layout_constraintTop_toTopOf="@id/title_tv"
+            app:layout_constraintStart_toEndOf="@id/title_tv"/>
 
         <ImageView
             android:id="@+id/delete_iv"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
     <string name="summary_loading_sub_message">잠시만 기다리면 요약이 상담 기록에 저장됩니다.</string>
 
     <string name="summary_not_generated">아직 요약이 생성되지 않았어요.</string>
-    <string name="retry_summary">요약 다시 생성</string>
+    <string name="retry_summary">요약 생성</string>
 
     <string name="summary_error_message">요약 생성 중 오류가 발생했어요.\n상담 기록 화면에서 다시 시도해 주세요.</string>
     <string name="summary_timeout_message">요약 생성이 지연되어 기록 화면으로 이동합니다.\n기록에서 \'요약 다시 생성\'을 눌러 나중에 다시 시도할 수 있어요.</string>


### PR DESCRIPTION
## 📝 작업 내용
상담을 진행하다가 히스토리 버튼을 클릭하여 상담 목록을 조회하려고 하면 이전 상담 세션은 종료되기 때문에, 상담을 진행하던 도중 히스토리 버튼 클릭 시 "현재 상담이 종료되지 않았습니다. 기록을 조회하러 가시겠습니까?" 같은 문구를 다이얼로그에 표시

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 상담 기록 조회 시 활성 세션 확인 대화상자 추가
  * 진행 중인 세션이 있는 경우 확인 프롬프트 표시
  * 사용자 선택에 따라 세션 종료 후 기록 이동

## UI 개선
* 상담 기록 항목 레이아웃 최적화
  * 여백 조정 및 요소 배치 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->