### PR TITLE
[Feat/#137] 토큰 카운팅 플래그 추가

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/consult/ConsultFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/ConsultFragment.kt
@@ -64,6 +64,7 @@ class ConsultFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         binding.endIv.visibility = View.GONE
+        binding.plusIv.visibility = View.GONE
 
         currentSessionId = null // 이전 세션 ID 무효화
         viewModel.resetMessages() // 말풍선 / 에이전트 버퍼 모두 초기화
@@ -132,6 +133,14 @@ class ConsultFragment : Fragment() {
                     endSession()
                 }
                 .show()
+        }
+
+        binding.plusIv.setOnClickListener {
+            if (viewModel.isStreamingNow()) {
+                Toast.makeText(requireContext(), "이전 답변을 생성 중입니다.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+            restartConsultSession()
         }
 
         binding.sendBtn.setOnClickListener {
@@ -211,6 +220,7 @@ class ConsultFragment : Fragment() {
         viewModel.startConsult.observe(viewLifecycleOwner) { response ->
             currentSessionId = response.sessionId
             binding.endIv.visibility = View.GONE
+            binding.plusIv.visibility = View.GONE
         }
 
         viewModel.messages.observe(viewLifecycleOwner) { list ->
@@ -285,6 +295,7 @@ class ConsultFragment : Fragment() {
             // 토큰 초과로 서버에서 이미 세션이 종료된 상태
             currentSessionId = null
             binding.endIv.visibility = View.GONE
+            binding.plusIv.visibility = View.VISIBLE
         }
 
         viewModel.summaryResult.observe(viewLifecycleOwner) { summaryRow ->
@@ -418,6 +429,17 @@ class ConsultFragment : Fragment() {
         summaryTimeoutJob = null
         summaryDialog?.dismiss()
         summaryDialog = null
+    }
+
+    private fun restartConsultSession() {
+        currentSessionId = null
+
+        viewModel.resetMessages()
+        showQuickQuestions()
+        binding.endIv.visibility = View.GONE
+        binding.plusIv.visibility = View.GONE
+
+        viewModel.startConsult() // 새 상담 시작
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/momolabfe/ui/consult/ConsultFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/ConsultFragment.kt
@@ -281,6 +281,12 @@ class ConsultFragment : Fragment() {
             }
         }
 
+        viewModel.autoEndSession.observe(viewLifecycleOwner) {
+            // 토큰 초과로 서버에서 이미 세션이 종료된 상태
+            currentSessionId = null
+            binding.endIv.visibility = View.GONE
+        }
+
         viewModel.summaryResult.observe(viewLifecycleOwner) { summaryRow ->
             if (summaryRow == null) return@observe
 

--- a/app/src/main/java/com/example/momolabfe/ui/consult/adapter/ChatAdapter.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/adapter/ChatAdapter.kt
@@ -1,6 +1,7 @@
 package com.example.momolabfe.ui.consult.adapter
 
 import android.content.Context
+import android.graphics.Typeface
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.view.animation.Animation
@@ -83,9 +84,22 @@ class ChatAdapter :
                 // 타이핑 인디케이터 + 애니메이션 효과
                 binding.agentMsgTv.text = binding.root.context.getString(R.string.typing_indicator)
                 binding.agentMsgTv.startAnimation(getTypingAnimation(binding.root.context))
+                return
+            }
+
+            binding.agentMsgTv.clearAnimation()
+
+            if (item.isTokenWarning) {
+                // 토큰 경고 말풍선 스타일
+                binding.agentMsgTv.setTextColor(binding.root.context.getColor(R.color.red))
+                binding.agentMsgTv.setTypeface(null, Typeface.BOLD)
+
+                // 경고 문구는 마크다운 파싱 필요 없으면 그냥 text
+                binding.agentMsgTv.text = item.text
             } else {
-                // 애니메이션 제거 + 실제 응답 표시
-                binding.agentMsgTv.clearAnimation()
+                binding.agentMsgTv.setTypeface(null, Typeface.NORMAL)
+
+                // 마크다운 처리
                 setMarkdownBold(binding.agentMsgTv, item.text)
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/consult/adapter/ChatAdapter.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/adapter/ChatAdapter.kt
@@ -97,6 +97,7 @@ class ChatAdapter : ListAdapter<ChatMessage, RecyclerView.ViewHolder>(DiffCallba
                 // 경고 문구는 마크다운 파싱 필요 없으면 그냥 text
                 binding.agentMsgTv.text = item.text
             } else {
+                binding.agentMsgTv.setTextColor(binding.root.context.getColor(R.color.text_primary))
                 binding.agentMsgTv.setTypeface(null, Typeface.NORMAL)
 
                 // 마크다운 처리

--- a/app/src/main/java/com/example/momolabfe/ui/consult/adapter/ChatAdapter.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/adapter/ChatAdapter.kt
@@ -16,8 +16,7 @@ import com.example.momolabfe.databinding.ItemChatAgentBinding
 import com.example.momolabfe.databinding.ItemChatUserBinding
 import com.example.momolabfe.ui.consult.data.ChatMessage
 
-class ChatAdapter :
-    ListAdapter<ChatMessage, RecyclerView.ViewHolder>(DiffCallback) {
+class ChatAdapter : ListAdapter<ChatMessage, RecyclerView.ViewHolder>(DiffCallback) {
 
     private var typingAnimation: Animation? = null
     private fun getTypingAnimation(context: Context): Animation {
@@ -42,7 +41,8 @@ class ChatAdapter :
     }
 
     override fun getItemViewType(position: Int): Int {
-        return if (getItem(position).isUser) TYPE_USER else TYPE_AGENT
+        val item = getItem(position)
+        return if (item.isUser) TYPE_USER else TYPE_AGENT
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {

--- a/app/src/main/java/com/example/momolabfe/ui/consult/adapter/ChatAdapter.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/adapter/ChatAdapter.kt
@@ -41,8 +41,7 @@ class ChatAdapter : ListAdapter<ChatMessage, RecyclerView.ViewHolder>(DiffCallba
     }
 
     override fun getItemViewType(position: Int): Int {
-        val item = getItem(position)
-        return if (item.isUser) TYPE_USER else TYPE_AGENT
+        return if (getItem(position).isUser) TYPE_USER else TYPE_AGENT
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {

--- a/app/src/main/java/com/example/momolabfe/ui/consult/data/ChatMessage.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/data/ChatMessage.kt
@@ -4,5 +4,6 @@ data class ChatMessage(
     val id: Long,
     val text: String,
     val isUser: Boolean, // true면 오른쪽(환자), false면 왼쪽(에이전트)
-    val isTyping: Boolean = false // 에이전트 입력 중 상태를 위한 플래그
+    val isTyping: Boolean = false, // 에이전트 입력 중 상태를 위한 플래그
+    val isTokenWarning: Boolean = false, // 토큰 경고 말풍선인지
 )

--- a/app/src/main/java/com/example/momolabfe/ui/consult/data/ChatMessage.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/data/ChatMessage.kt
@@ -6,5 +6,4 @@ data class ChatMessage(
     val isUser: Boolean, // true면 오른쪽(환자), false면 왼쪽(에이전트)
     val isTyping: Boolean = false, // 에이전트 입력 중 상태를 위한 플래그
     val isTokenWarning: Boolean = false, // 토큰 경고 말풍선인지
-    val isSessionEndAction: Boolean = false, // 세션 종료용 액션 말풍선인지
 )

--- a/app/src/main/java/com/example/momolabfe/ui/consult/data/ChatMessage.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/data/ChatMessage.kt
@@ -6,4 +6,5 @@ data class ChatMessage(
     val isUser: Boolean, // true면 오른쪽(환자), false면 왼쪽(에이전트)
     val isTyping: Boolean = false, // 에이전트 입력 중 상태를 위한 플래그
     val isTokenWarning: Boolean = false, // 토큰 경고 말풍선인지
+    val isSessionEndAction: Boolean = false, // 세션 종료용 액션 말풍선인지
 )

--- a/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
@@ -75,8 +75,8 @@ class ConsultViewModel @Inject constructor(
     val summaryUiState: StateFlow<SummaryUiState> = _summaryUiState.asStateFlow()
 
     // 자동 토큰 종료 이벤트
-    private val _autoEndSession = MutableLiveData<Unit>()
-    val autoEndSession: LiveData<Unit> get() = _autoEndSession
+    private val _autoEndSession = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val autoEndSession: SharedFlow<Unit> = _autoEndSession.asSharedFlow()
 
     // 상담 시작
     fun startConsult() {
@@ -116,7 +116,7 @@ class ConsultViewModel @Inject constructor(
                             val warnText = chunk.removePrefix("[TOKEN_WARN]").trim()
 
                             if (warnText.isNotEmpty()) {
-                                appendAgentMessage("**[세션 경고]** $warnText")
+                                appendTokenWarningMessage("[세션 경고] $warnText")
                             }
 
                             // 경고는 스트리밍 버퍼에 포함시키지 않음
@@ -130,11 +130,11 @@ class ConsultViewModel @Inject constructor(
                             removeTypingBubble()
 
                             if (endText.isNotEmpty()) {
-                                appendAgentMessage("**[세션 종료 안내]** $endText")
+                                appendSessionEndMessage("[세션 종료 안내] $endText")
                             }
 
                             endedByToken = true
-                            _autoEndSession.postValue(Unit) // 세션 자동 종료 신호 전송
+                            _autoEndSession.tryEmit(Unit) // 세션 자동 종료 신호 전송
 
                             return@collect
                         }
@@ -374,6 +374,33 @@ class ConsultViewModel @Inject constructor(
             current.removeAt(idx)
             _messages.value = current
         }
+    }
+
+    // 토큰 경고 메시지
+    private fun appendTokenWarningMessage(text: String) {
+        val current = _messages.value.orEmpty().toMutableList()
+        current.add(
+            ChatMessage(
+                id = nextId(),
+                text = text,
+                isUser = false,
+                isTokenWarning = true
+            )
+        )
+        _messages.value = current
+    }
+
+    // 세션 종료 안내 메시지
+    private fun appendSessionEndMessage(text: String) {
+        val current = _messages.value.orEmpty().toMutableList()
+        current.add(
+            ChatMessage(
+                id = nextId(),
+                text = text,
+                isUser = false,
+            )
+        )
+        _messages.value = current
     }
 
     // 새 상담 시작 시 히스토리 초기화

--- a/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
@@ -74,6 +74,10 @@ class ConsultViewModel @Inject constructor(
     private val _summaryUiState = MutableStateFlow(SummaryUiState())
     val summaryUiState: StateFlow<SummaryUiState> = _summaryUiState.asStateFlow()
 
+    // 자동 토큰 종료 이벤트
+    private val _autoEndSession = MutableLiveData<Unit>()
+    val autoEndSession: LiveData<Unit> get() = _autoEndSession
+
     // 상담 시작
     fun startConsult() {
         viewModelScope.launch {
@@ -99,13 +103,49 @@ class ConsultViewModel @Inject constructor(
         viewModelScope.launch {
             isStreaming = true
             var buffer = ""
+            var endedByToken = false // [TOKEN_END]로 종료됐는지 여부
 
             showAgentTyping()
 
             try {
-                // chunk 들어올 때마다 버퍼 누적 + 그 버퍼로 마지막 에이전트 말풍선 갱신
                 consultRepository.chatStream(request)
                     .collect { chunk ->
+
+                        // 토큰 경고 처리
+                        if (chunk.startsWith("[TOKEN_WARN]")) {
+                            val warnText = chunk.removePrefix("[TOKEN_WARN]").trim()
+
+                            if (warnText.isNotEmpty()) {
+                                appendAgentMessage("**[세션 경고]** $warnText")
+                            }
+
+                            // 경고는 스트리밍 버퍼에 포함시키지 않음
+                            return@collect
+                        }
+
+                        // 토큰 한도 종료 안내 처리
+                        if (chunk.startsWith("[TOKEN_END]")) {
+                            val endText = chunk.removePrefix("[TOKEN_END]").trim()
+
+                            removeTypingBubble()
+
+                            if (endText.isNotEmpty()) {
+                                appendAgentMessage("**[세션 종료 안내]** $endText")
+                            }
+
+                            endedByToken = true
+
+                            _autoEndSession.postValue(Unit) // 세션 자동 종료 신호 전송
+
+                            return@collect
+                        }
+
+                        // 이미 [TOKEN_END]로 종료 처리된 상태라면 모든 chunk 무시
+                        if (endedByToken) {
+                            return@collect
+                        }
+
+                        // LLM 응답 스트리밍 처리
                         buffer += chunk
                         updateAgentStreamingMessage(buffer)
                     }
@@ -113,7 +153,10 @@ class ConsultViewModel @Inject constructor(
                 _errorMessage.value = e.localizedMessage ?: "에이전트 대화 중 오류가 발생했습니다."
             } finally {
                 isStreaming = false
-                markAgentMessageCompleted()
+
+                if (!endedByToken) {
+                    markAgentMessageCompleted()
+                }
             }
         }
     }
@@ -185,7 +228,7 @@ class ConsultViewModel @Inject constructor(
     }
 
     // 특정 상담 세션 요약
-    fun summaryConsult(sessionId: String) {
+    private fun summaryConsult(sessionId: String) {
         viewModelScope.launch {
 
             val result = consultRepository.summaryConsult(sessionId)
@@ -248,13 +291,18 @@ class ConsultViewModel @Inject constructor(
     private fun updateAgentStreamingMessage(fullText: String) {
         val current = _messages.value.orEmpty().toMutableList()
 
-        if (current.isNotEmpty() && !current.last().isUser) {
-            val last = current.last()
-            current[current.lastIndex] = last.copy(
+        // 마지막 타이핑 중인 에이전트 말풍선 찾기
+        val lastTypingIndex = current.indexOfLast { msg ->
+            !msg.isUser && msg.isTyping
+        }
+
+        if (lastTypingIndex != -1) {
+            val last = current[lastTypingIndex]
+            current[lastTypingIndex] = last.copy(
                 text = fullText,
             )
         } else {
-            // 에이전트 말풍선이 없으면 새로 하나 생성
+            // 타이핑 말풍선이 없으면 새로 생성
             current.add(
                 ChatMessage(
                     id = nextId(),
@@ -264,6 +312,7 @@ class ConsultViewModel @Inject constructor(
                 )
             )
         }
+
         _messages.value = current
         _agentMessage.value = fullText
     }
@@ -281,12 +330,16 @@ class ConsultViewModel @Inject constructor(
     // 답변 완료 마킹 함수
     private fun markAgentMessageCompleted() {
         val current = _messages.value.orEmpty().toMutableList()
-        if (current.isNotEmpty() && !current.last().isUser) {
-            val last = current.last()
-            if (last.isTyping) {
-                current[current.lastIndex] = last.copy(isTyping = false)
-                _messages.value = current
-            }
+
+        // 마지막 타이핑 중인 에이전트 말풍선 찾아서 isTyping = false로 변경
+        val idx = current.indexOfLast { msg ->
+            !msg.isUser && msg.isTyping
+        }
+
+        if (idx != -1) {
+            val last = current[idx]
+            current[idx] = last.copy(isTyping = false)
+            _messages.value = current
         }
     }
 
@@ -310,6 +363,18 @@ class ConsultViewModel @Inject constructor(
         )
 
         summaryConsult(sessionId)
+    }
+
+    // 타이핑 말풍선 제거
+    private fun removeTypingBubble() {
+        val current = _messages.value.orEmpty().toMutableList()
+        val idx = current.indexOfLast { msg ->
+            !msg.isUser && msg.isTyping
+        }
+        if (idx != -1) {
+            current.removeAt(idx)
+            _messages.value = current
+        }
     }
 
     // 새 상담 시작 시 히스토리 초기화

--- a/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
@@ -134,7 +134,6 @@ class ConsultViewModel @Inject constructor(
                             }
 
                             endedByToken = true
-
                             _autoEndSession.postValue(Unit) // 세션 자동 종료 신호 전송
 
                             return@collect

--- a/app/src/main/res/layout/fragment_consult.xml
+++ b/app/src/main/res/layout/fragment_consult.xml
@@ -42,6 +42,16 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <ImageView
+            android:id="@+id/plus_iv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="30dp"
+            android:visibility="gone"
+            android:src="@drawable/ic_plus_sv"
+            app:layout_constraintEnd_toStartOf="@id/history_iv"
+            app:layout_constraintTop_toTopOf="@id/history_iv" />
+
+        <ImageView
             android:id="@+id/end_iv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
## 📝 작업 내용
8000 토큰의 95%를 초과하면 경고 문구를 표시하며, 8000 토큰을 초과하면 상담 세션이 자동으로 종료되면서 종료 문구를 표시합니다.
상담이 자동으로 종료되는 경우 우측 상단에 플러스 버튼을 추가하여, 이를 클릭하면 새로운 상담을 시작할 수 있습니다.
이전에 자동으로 종료된 상담은 목록 조회 화면에서 요약을 생성할 수 있습니다.

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 플러스 버튼으로 상담 세션을 즉시 재시작할 수 있습니다(세션 초기화·빠른 질문 표시).  
  * 토큰 기반 자동 세션 종료가 도입되어 특정 상황에서 세션이 자동으로 종료됩니다.

* **UI 개선**
  * 토큰 경고 메시지가 빨간색 굵은 텍스트로 명확히 표시됩니다.
  * 플러스/종료 버튼의 표시가 세션 시작·자동종료 시점에 따라 자동으로 전환되고, 관련 토스트 알림이 제공됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->