### PR TITLE
[BUG/#141] OCR 인식 시 공통 화면 네비바 노출되는 문제

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordOcrLoadingFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordOcrLoadingFragment.kt
@@ -231,7 +231,6 @@ class RecordOcrLoadingFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        activity?.findViewById<BottomNavigationView>(R.id.main_bnv)?.visibility = View.VISIBLE
         super.onDestroyView()
         _binding = null
     }


### PR DESCRIPTION
## 📝 작업 내용
이전 화면인 OcrLoadingFragment의 onDestroyView에서 `activity?.findViewById<BottomNavigationView>(R.id.main_bnv)?.visibility = View.VISIBLE` 를 처리하게 되면 다음 화면에서 네비바가 보이게 됨 -> 이를 삭제하여 해결

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* OCR 녹음 화면 종료 시 하단 네비게이션 바의 가시성 동작이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->