### PR TITLE
[REFACTOR/#143] 토큰 경고 문구 출력 순서 변경

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/consult/adapter/ChatAdapter.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/adapter/ChatAdapter.kt
@@ -79,6 +79,9 @@ class ChatAdapter : ListAdapter<ChatMessage, RecyclerView.ViewHolder>(DiffCallba
     ) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(item: ChatMessage) {
+
+            val context = binding.root.context
+
             if (item.isTyping) {
                 // 타이핑 인디케이터 + 애니메이션 효과
                 binding.agentMsgTv.text = binding.root.context.getString(R.string.typing_indicator)
@@ -88,19 +91,28 @@ class ChatAdapter : ListAdapter<ChatMessage, RecyclerView.ViewHolder>(DiffCallba
 
             binding.agentMsgTv.clearAnimation()
 
-            if (item.isTokenWarning) {
-                // 토큰 경고 말풍선 스타일
-                binding.agentMsgTv.setTextColor(binding.root.context.getColor(R.color.red))
-                binding.agentMsgTv.setTypeface(null, Typeface.BOLD)
 
-                // 경고 문구는 마크다운 파싱 필요 없으면 그냥 text
-                binding.agentMsgTv.text = item.text
-            } else {
-                binding.agentMsgTv.setTextColor(binding.root.context.getColor(R.color.text_primary))
-                binding.agentMsgTv.setTypeface(null, Typeface.NORMAL)
+            when {
+                // 세션 경고
+                item.isTokenWarning -> {
+                    binding.agentMsgTv.setTextColor(context.getColor(R.color.warning_yellow))
+                    binding.agentMsgTv.setTypeface(null, Typeface.BOLD)
+                    binding.agentMsgTv.text = item.text
+                }
 
-                // 마크다운 처리
-                setMarkdownBold(binding.agentMsgTv, item.text)
+                // 세션 종료
+                item.isSessionEnd -> {
+                    binding.agentMsgTv.setTextColor(context.getColor(R.color.red))
+                    binding.agentMsgTv.setTypeface(null, Typeface.BOLD)
+                    binding.agentMsgTv.text = item.text
+                }
+
+                // 일반 에이전트 답변
+                else -> {
+                    binding.agentMsgTv.setTextColor(context.getColor(R.color.text_primary))
+                    binding.agentMsgTv.setTypeface(null, Typeface.NORMAL)
+                    setMarkdownBold(binding.agentMsgTv, item.text)
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/momolabfe/ui/consult/data/ChatMessage.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/data/ChatMessage.kt
@@ -6,4 +6,5 @@ data class ChatMessage(
     val isUser: Boolean, // true면 오른쪽(환자), false면 왼쪽(에이전트)
     val isTyping: Boolean = false, // 에이전트 입력 중 상태를 위한 플래그
     val isTokenWarning: Boolean = false, // 토큰 경고 말풍선인지
+    val isSessionEnd: Boolean = false, // 세션 종료 말풍선인지
 )

--- a/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
@@ -104,8 +104,10 @@ class ConsultViewModel @Inject constructor(
             isStreaming = true
             var buffer = ""
             var endedByToken = false // [TOKEN_END]로 종료됐는지 여부
+            var typingShown = false // "답변 생성 중.." 말풍선이 실제로 화면에 나갔는지 여부
 
             showAgentTyping()
+            typingShown = true
 
             try {
                 consultRepository.chatStream(request)
@@ -116,7 +118,15 @@ class ConsultViewModel @Inject constructor(
                             val warnText = chunk.removePrefix("[TOKEN_WARN]").trim()
 
                             if (warnText.isNotEmpty()) {
+                                if (typingShown) {
+                                    removeTypingBubble()
+                                    typingShown = false
+                                }
+
                                 appendTokenWarningMessage("[세션 경고] $warnText")
+
+                                showAgentTyping()
+                                typingShown = true
                             }
 
                             // 경고는 스트리밍 버퍼에 포함시키지 않음
@@ -127,7 +137,11 @@ class ConsultViewModel @Inject constructor(
                         if (chunk.startsWith("[TOKEN_END]")) {
                             val endText = chunk.removePrefix("[TOKEN_END]").trim()
 
-                            removeTypingBubble()
+                            // 타이핑 말풍선이 이미 켜져 있다면 제거
+                            if (typingShown) {
+                                removeTypingBubble()
+                                typingShown = false
+                            }
 
                             if (endText.isNotEmpty()) {
                                 appendSessionEndMessage("[세션 종료 안내] $endText")
@@ -398,6 +412,7 @@ class ConsultViewModel @Inject constructor(
                 id = nextId(),
                 text = text,
                 isUser = false,
+                isSessionEnd = true
             )
         )
         _messages.value = current

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordOcrLoadingFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordOcrLoadingFragment.kt
@@ -12,8 +12,6 @@ import com.bumptech.glide.Glide
 import com.example.momolabfe.R
 import com.example.momolabfe.databinding.FragmentRecordOcrLoadingBinding
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -18,6 +18,7 @@
     <color name="bg_light_blue">#eff6ff</color>
     <color name="indigo">#6366F1</color>
     <color name="red">#FF0000</color>
+    <color name="warning_yellow">#FFC107</color>
 
     <color name="gray">#C2C4C6</color>
     <color name="deactive">#B1B2B3</color>


### PR DESCRIPTION
## 📝 작업 내용
기존에는 에이전트 답변 아래에 토큰 경고 문구가 출력되는 구조여서, 아래에 토큰 경고 문구가 먼저 출력되고 에이전트는 "답변 생성 중.." -> 답변 출력 되는 구조였습니다. 이를 경고 문구 먼저 출력하고, 에이전트의 답변이 오도록 순서를 변경하였습니다.
또한 경고 문구일 경우 노란색 볼드체, 종료 문구일 경우 빨간색 볼드체로 처리하였습니다.

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 채팅 메시지 표시 개선: 토큰 경고와 세션 종료 상태를 시각적으로 구분하여 표시
  * 타이핑 인디케이터 처리 최적화로 메시지 흐름 개선

* **최적화**
  * 불필요한 코드 정리로 성능 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->