### PR TITLE
[REFACTOR/#150] 제수량이 일치하지 않으면 홈화면에서 빨간색 표시

### DIFF
--- a/app/src/main/java/com/example/momolabfe/remote/record/model/RecordResponse.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/record/model/RecordResponse.kt
@@ -78,5 +78,6 @@ data class WeeklyAverageResponse (
 data class TodayExchangeSummary (
     @SerializedName("has_record") val hasRecord: Boolean,
     @SerializedName("exchange_count") val exchangeCount: Int,
-    @SerializedName("total_uf") val totalUf: Int
+    @SerializedName("total_uf") val totalUf: Int,
+    @SerializedName("record_uf_sum") val recordUfSum: Int
 )

--- a/app/src/main/java/com/example/momolabfe/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/main/HomeFragment.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -116,6 +117,13 @@ class HomeFragment : Fragment() {
 
             binding.completeContentTv.text = "${summary.exchangeCount} / 5회"
             binding.ufContentTv.text = String.format(Locale.KOREA, "%dg", summary.totalUf)
+
+            val isMismatch = summary.totalUf != summary.recordUfSum
+
+            val colorResId = if (isMismatch) R.color.red else R.color.secondary_text
+            binding.ufContentTv.setTextColor(
+                ContextCompat.getColor(requireContext(), colorResId)
+            )
         }
 
         recordViewModel.recordlistItems.observe(viewLifecycleOwner) { itemList ->


### PR DESCRIPTION
## 📝 작업 내용
제수량이 일치하지 않으면 홈화면에서 빨간색 표시

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * UF 데이터 불일치 감지 기능 추가: 계산된 합계와 기록된 합계가 일치하지 않을 경우 해당 영역이 빨간색으로 표시되어 사용자에게 시각적 경고 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->