### PR TITLE
[BUG/#152] OCR 인식되지 않은 데이터들이 not null로 처리되는 문제

### DIFF
--- a/app/src/main/java/com/example/momolabfe/remote/record/model/RecordResponse.kt
+++ b/app/src/main/java/com/example/momolabfe/remote/record/model/RecordResponse.kt
@@ -37,31 +37,31 @@ data class RecordOcrResponse (
 )
 
 data class OcrRecordData (
-    @SerializedName("record_date") val recordDate: LocalDate,
-    @SerializedName("record_dw") val recordDw: DayWeek,
-    @SerializedName("weight") val weight: Double,
-    @SerializedName("blood_pressure") val bloodPressure: BpData,
-    @SerializedName("fasting_glucose") val fastingGlucose: Int,
-    @SerializedName("urine_count") val urineCount: Int,
-    @SerializedName("turbidity") val turbidity: Turbidity,
+    @SerializedName("record_date") val recordDate: LocalDate?,
+    @SerializedName("record_dw") val recordDw: DayWeek?,
+    @SerializedName("weight") val weight: Double?,
+    @SerializedName("blood_pressure") val bloodPressure: BpData?,
+    @SerializedName("fasting_glucose") val fastingGlucose: Int?,
+    @SerializedName("urine_count") val urineCount: Int?,
+    @SerializedName("turbidity") val turbidity: Turbidity?,
     @SerializedName("notes") val notes: String?,
-    @SerializedName("total_uf") val totalUf: Int,
+    @SerializedName("total_uf") val totalUf: Int?,
     @SerializedName("exchanges") val exchanges: List<OcrRecordExchangeData> = emptyList()
 )
 
 data class BpData (
-    @SerializedName("systolic") val systolic: Int,
-    @SerializedName("diastolic") val diastolic: Int
+    @SerializedName("systolic") val systolic: Int?,
+    @SerializedName("diastolic") val diastolic: Int?
 )
 
 data class OcrRecordExchangeData (
-    @SerializedName("id") val id: Long,
-    @SerializedName("exchange_no") val exchangeNo: Int,
-    @SerializedName("exchange_time") val exchangeTime: LocalTime,
-    @SerializedName("drain_volume") val drainVolume: Int,
-    @SerializedName("fill_volume") val fillVolume: Int,
-    @SerializedName("fill_concentration") val fillConcentration: Double,
-    @SerializedName("uf") val uf: Int
+    @SerializedName("id") val id: Long? = null,
+    @SerializedName("exchange_no") val exchangeNo: Int?,
+    @SerializedName("exchange_time") val exchangeTime: LocalTime?,
+    @SerializedName("drain_volume") val drainVolume: Int?,
+    @SerializedName("fill_volume") val fillVolume: Int?,
+    @SerializedName("fill_concentration") val fillConcentration: Double?,
+    @SerializedName("uf") val uf: Int?
 )
 
 data class WeeklyAverageData (

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite01Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite01Fragment.kt
@@ -651,7 +651,7 @@ class RecordWrite01Fragment : Fragment() {
                 null -> {}
             }
 
-            binding.notesEt.setText(ocr.ocrData.notes ?: "")
+            binding.notesEt.setText(ocrData.notes ?: "")
 
             // gCS Path를 사용하여 이미지 다운로드 시작
             val gcsPath = ocr.gcsPath

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite01Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite01Fragment.kt
@@ -587,25 +587,68 @@ class RecordWrite01Fragment : Fragment() {
 
             isOcrApplied = true  // 다시 덮어쓰지 않도록 플래그 ON
 
-            val recordDate = ocr.ocrData.recordDate
-            selectedDate = recordDate
+            val ocrData = ocr.ocrData
 
-            // 이 날짜가 속한 달 데이터 미리 요청
-            viewModel.getCalendar(recordDate.year, recordDate.monthValue)
+            val recordDate = ocrData.recordDate
+            if (recordDate != null) {
+                selectedDate = recordDate
 
-            binding.dateEt.setText(ocr.ocrData.recordDate.format(displayFormatter))
-            binding.weightEt.setText(ocr.ocrData.weight.toString())
-            binding.systolicEt.setText(ocr.ocrData.bloodPressure.systolic.toString())
-            binding.diastolicEt.setText(ocr.ocrData.bloodPressure.diastolic.toString())
-            binding.fastingGlucoseEt.setText(ocr.ocrData.fastingGlucose.toString())
-            binding.urineCountEt.setText(ocr.ocrData.urineCount.toString())
+                viewModel.getCalendar(recordDate.year, recordDate.monthValue) // 이 날짜가 속한 달 데이터 미리 요청
+                binding.dateEt.setText(recordDate.format(displayFormatter))
+            } else {
+                selectedDate = null
+                binding.dateEt.setText("")
+            }
+
+            val weight = ocrData.weight
+            if (weight != null) {
+                binding.weightEt.setText(weight.toString())
+            } else {
+                binding.weightEt.text?.clear()
+            }
+
+            val bp = ocrData.bloodPressure
+            if (bp != null) {
+                val sys = bp.systolic
+                val dia = bp.diastolic
+
+                if (sys != null) {
+                    binding.systolicEt.setText(sys.toString())
+                } else {
+                    binding.systolicEt.text?.clear()
+                }
+
+                if (dia != null) {
+                    binding.diastolicEt.setText(dia.toString())
+                } else {
+                    binding.diastolicEt.text?.clear()
+                }
+            } else {
+                binding.systolicEt.text?.clear()
+                binding.diastolicEt.text?.clear()
+            }
+
+            val fastingGlucose = ocrData.fastingGlucose
+            if (fastingGlucose != null) {
+                binding.fastingGlucoseEt.setText(fastingGlucose.toString())
+            } else {
+                binding.fastingGlucoseEt.text?.clear()
+            }
+
+            val urineCount = ocrData.urineCount
+            if (urineCount != null) {
+                binding.urineCountEt.setText(urineCount.toString())
+            } else {
+                binding.urineCountEt.text?.clear()
+            }
 
             binding.turbidityNCheckbox.isChecked = false
             binding.turbidityYCheckbox.isChecked = false
 
-            when (ocr.ocrData.turbidity) {
+            when (ocrData.turbidity) {
                 Turbidity.NONE -> binding.turbidityNCheckbox.isChecked = true
                 Turbidity.PRESENT -> binding.turbidityYCheckbox.isChecked = true
+                null -> {}
             }
 
             binding.notesEt.setText(ocr.ocrData.notes ?: "")

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
@@ -244,13 +244,13 @@ class RecordWrite02Fragment : Fragment() {
         val newExchangeNo = exchangeList.size + 1
 
         val newExchange = OcrRecordExchangeData(
-            id = -1,
+            id = null,
             exchangeNo = newExchangeNo,
-            exchangeTime = LocalTime.now(),
-            drainVolume = -1,
-            fillConcentration = -1.0,
-            fillVolume = -1,
-            uf = -999
+            exchangeTime = null,
+            drainVolume = null,
+            fillConcentration = null,
+            fillVolume = null,
+            uf = null
         )
 
         exchangeList.add(newExchange)
@@ -269,11 +269,11 @@ class RecordWrite02Fragment : Fragment() {
         if (exchangesFromOcr.isEmpty()) {
             // 1회차 항목을 생성하여 추가
             val firstExchange = OcrRecordExchangeData(
-                id = -1, // 임시 ID
+                id = null,
                 exchangeNo = 1,
-                exchangeTime = LocalTime.now(),
-                drainVolume = -1,
-                fillConcentration = -1.0,
+                exchangeTime = null,
+                drainVolume = null,
+                fillConcentration = null,
                 fillVolume = -1,
                 uf = -999
             )
@@ -356,51 +356,58 @@ class RecordWrite02Fragment : Fragment() {
 
         val requestList = mutableListOf<RecordExchangeCreateRequest>()
         for (item in exchanges) {
+            val exNo = item.exchangeNo ?: 0
 
-            if (item.drainVolume == -1) {
-                showError("${item.exchangeNo}회차 배액량을 입력해주세요.")
+            if (item.exchangeTime == null) {
+                showError("${exNo}회차 시간을 입력해주세요.")
                 enableButtonAndReturn()
                 return
             }
 
-            if (item.fillVolume == -1) {
-                showError("${item.exchangeNo}회차 주입량을 입력해주세요.")
+            if (item.drainVolume == null) {
+                showError("${exNo}회차 배액량을 입력해주세요.")
                 enableButtonAndReturn()
                 return
             }
 
-            if (item.fillConcentration == -1.0) {
-                showError("${item.exchangeNo}회차 주입액 농도를 입력해주세요.")
+            if (item.fillVolume == null) {
+                showError("${exNo}회차 주입량을 입력해주세요.")
                 enableButtonAndReturn()
                 return
             }
 
-            if (item.uf == -999) {
-                showError("${item.exchangeNo}회차 제수량을 입력해주세요.")
+            if (item.fillConcentration == null) {
+                showError("${exNo}회차 주입액 농도를 입력해주세요.")
+                enableButtonAndReturn()
+                return
+            }
+
+            if (item.uf == null) {
+                showError("${exNo}회차 제수량을 입력해주세요.")
                 enableButtonAndReturn()
                 return
             }
 
             if (item.drainVolume < 0 || item.drainVolume > 6000) {
-                showError("${item.exchangeNo}회차 배액량은 0 ~ 6000 g 사이로 입력해주세요. (현재: ${item.drainVolume})")
+                showError("${exNo}회차 배액량은 0 ~ 6000 g 사이로 입력해주세요. (현재: ${item.drainVolume})")
                 enableButtonAndReturn()
                 return
             }
 
             if (item.fillVolume < 0 || item.fillVolume > 6000) {
-                showError("${item.exchangeNo}회차 주입량은 0 ~ 6000 g 사이로 입력해주세요. (현재: ${item.fillVolume})")
+                showError("${exNo}회차 주입량은 0 ~ 6000 g 사이로 입력해주세요. (현재: ${item.fillVolume})")
                 enableButtonAndReturn()
                 return
             }
 
             if (item.fillConcentration < 0.0 || item.fillConcentration > 100.0) {
-                showError("${item.exchangeNo}회차 주입액 농도는 0.0 ~ 100.0 % 사이로 입력해주세요. (현재: ${item.fillConcentration})")
+                showError("${exNo}회차 주입액 농도는 0.0 ~ 100.0 % 사이로 입력해주세요. (현재: ${item.fillConcentration})")
                 enableButtonAndReturn()
                 return
             }
 
             if (item.uf < -500 || item.uf > 500) {
-                showError("${item.exchangeNo}회차 제수량은 -500 ~ 500 g 사이로 입력해주세요. (현재: ${item.uf})")
+                showError("${exNo}회차 제수량은 -500 ~ 500 g 사이로 입력해주세요. (현재: ${item.uf})")
                 enableButtonAndReturn()
                 return
             }
@@ -486,10 +493,10 @@ class RecordWrite02Fragment : Fragment() {
         var sumUf = 0
 
         exchanges.forEach { item ->
-            val uf = item.uf
+            val uf = item.uf!!
             sumUf += uf
 
-            val calculatedUf = item.drainVolume - item.fillVolume
+            val calculatedUf = item.drainVolume!! - item.fillVolume!!
             if (uf != calculatedUf) {
                 hasPerExchangeMismatch = true
             }
@@ -551,7 +558,7 @@ class RecordWrite02Fragment : Fragment() {
             }
             val isExpanded = expandedStates[index]
 
-            itemBinding.exchangeNoTv.text = "${index + 1}회차"
+            itemBinding.exchangeNoTv.text = "${item.exchangeNo ?: (index + 1)}회차"
 
             // 드롭다운 상태에 따라 보이기/숨기기
             itemBinding.detailsContainer.visibility =
@@ -625,46 +632,46 @@ class RecordWrite02Fragment : Fragment() {
                 }.show()
             }
 
-            val timeText = item.exchangeTime.format(TIME_FORMATTER)
+            val timeText = item.exchangeTime?.format(TIME_FORMATTER) ?: ""
             itemBinding.exchangeTimeEt.setText(timeText)
             itemBinding.exchangeTimeEt.setOnClickListener {
                 showTimePickerDialog(itemBinding.exchangeTimeEt, index)
             }
 
             itemBinding.drainVolumeEt.setText(
-                if (item.drainVolume == -1) "" else item.drainVolume.toString()
+                item.drainVolume?.toString() ?: ""
             )
             itemBinding.fillVolumeEt.setText(
-                if (item.fillVolume == -1) "" else item.fillVolume.toString()
+                item.fillVolume?.toString() ?: ""
             )
             itemBinding.fillConcentrationEt.setText(
-                if (item.fillConcentration == -1.0) "" else item.fillConcentration.toString()
+                item.fillConcentration?.toString() ?: ""
             )
             itemBinding.ufEt.setText(
-                if (item.uf == -999) "" else item.uf.toString()
+                item.uf?.toString() ?: ""
             )
 
             itemBinding.drainVolumeEt.addTextChangedListener {
                 val text = it?.toString()?.trim()
-                val v = if (text.isNullOrEmpty()) -1 else text.toIntOrNull() ?: -1
+                val v = text?.toIntOrNull()
                 exchangeList[index] = exchangeList[index].copy(drainVolume = v)
             }
 
             itemBinding.fillVolumeEt.addTextChangedListener {
                 val text = it?.toString()?.trim()
-                val v = if (text.isNullOrEmpty()) -1 else text.toIntOrNull() ?: -1
+                val v = text?.toIntOrNull()
                 exchangeList[index] = exchangeList[index].copy(fillVolume = v)
             }
 
             itemBinding.fillConcentrationEt.addTextChangedListener {
                 val text = it?.toString()?.trim()
-                val v = if (text.isNullOrEmpty()) -1.0 else text.toDoubleOrNull() ?: -1.0
+                val v = text?.toDoubleOrNull()
                 exchangeList[index] = exchangeList[index].copy(fillConcentration = v)
             }
 
             itemBinding.ufEt.addTextChangedListener {
                 val text = it?.toString()?.trim()
-                val v = if (text.isNullOrEmpty()) -999 else text.toIntOrNull() ?: -999
+                val v = text?.toIntOrNull()
                 exchangeList[index] = exchangeList[index].copy(uf = v)
             }
 

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
@@ -274,8 +274,8 @@ class RecordWrite02Fragment : Fragment() {
                 exchangeTime = null,
                 drainVolume = null,
                 fillConcentration = null,
-                fillVolume = -1,
-                uf = -999
+                fillVolume = null,
+                uf = null
             )
             exchangesFromOcr.add(firstExchange)
         }
@@ -493,10 +493,13 @@ class RecordWrite02Fragment : Fragment() {
         var sumUf = 0
 
         exchanges.forEach { item ->
-            val uf = item.uf!!
+            val uf = item.uf ?: return@forEach
             sumUf += uf
 
-            val calculatedUf = item.drainVolume!! - item.fillVolume!!
+            val drainVol = item.drainVolume ?: return@forEach
+            val fillVol = item.fillVolume ?: return@forEach
+            val calculatedUf = drainVol - fillVol
+
             if (uf != calculatedUf) {
                 hasPerExchangeMismatch = true
             }


### PR DESCRIPTION
## 📝 작업 내용
OCR 인식되지 않은 데이터들이 not null로 처리되는 문제
백엔드에서는 인식되지 않은 데이터 -> null로 표시하도록 하지만
프론트의 response에는 비고를 제외한 모든 필드가 not null이기 때문에 인식되지 못한 데이터들이 null로 처리되지 않고 터지는 것
펑 하고 터져서 바로 수정

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * OCR/서버에서 일부 필드가 누락돼도 앱이 안정적으로 동작하도록 처리 개선.
  * 불완전한 투석 교환 데이터 수신 시 직렬화 오류 방지 및 입력 초기화 개선.
* **사용성 개선**
  * 기록 작성 화면에서 각 항목(날짜, 체중, 혈압, 당, 소변 등)을 개별적으로 안전하게 적용/지우도록 개선.
  * 교환 항목 입력, 시간 선택 및 검증 로직을 null 안전성에 맞게 개선해 오류 메시지와 표시를 정확히 표시.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->