### PR TITLE
[BUG/#164] 기록 삭제 시 404 에러

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/record/BottomSheetRecordDeleteFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/BottomSheetRecordDeleteFragment.kt
@@ -62,7 +62,6 @@ class BottomSheetRecordDeleteFragment : BottomSheetDialogFragment() {
                 launch {
                     viewModel.deleteSuccess.collect {
                         Log.d("BOTTOM_SHEET_RECORD_DELETE", "기록이 성공적으로 삭제되었습니다.")
-                        parentFragmentManager.setFragmentResult("record_delete", Bundle())
                         dismiss()
                     }
                 }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordListFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordListFragment.kt
@@ -14,7 +14,10 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Observer
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.example.momolabfe.R
 import com.example.momolabfe.databinding.FragmentRecordListBinding
 import com.example.momolabfe.databinding.ItemExchangeDetailBinding
@@ -31,6 +34,7 @@ import com.kizitonwose.calendar.core.DayPosition
 import com.kizitonwose.calendar.view.CalendarView
 import com.kizitonwose.calendar.view.MonthDayBinder
 import com.kizitonwose.calendar.view.ViewContainer
+import kotlinx.coroutines.launch
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
@@ -250,16 +254,6 @@ class RecordListFragment : Fragment() {
             bottomSheet.show(parentFragmentManager, "BottomSheetRecordDelete")
         }
 
-        // 기록 삭제 성공 이벤트 수신
-        parentFragmentManager.setFragmentResultListener("record_delete", viewLifecycleOwner) { _, _ ->
-            // 현재 보여지는 달 기준으로 다시 조회
-            val year = visibleMonth.year
-            val monthValue = visibleMonth.monthValue
-
-            viewModel.getCalendar(year, monthValue)
-            viewModel.getRecordList(year, monthValue)
-        }
-
         hideDetailViews()
     }
 
@@ -367,6 +361,28 @@ class RecordListFragment : Fragment() {
                 hideDetailViews()
                 clearRecordViews()
                 renderExchanges(emptyList())
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.deleteSuccess.collect {
+
+                        Log.d("RECORD_LIST_FRAGMENT", "deleteSuccess 수신 - 캘린더/리스트 재조회 및 상세 초기화")
+
+                        val year = visibleMonth.year
+                        val monthValue = visibleMonth.monthValue
+
+                        viewModel.getCalendar(year, monthValue)
+                        viewModel.getRecordList(year, monthValue)
+
+                        selectedRecordId = null
+                        hideDetailViews()
+                        clearRecordViews()
+                        renderExchanges(emptyList())
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## 📝 작업 내용
기록 삭제 시 404 에러가 발생하며 바텀시트가 제대로 닫히지 않던 문제 해결
알고보니 기록 삭제 api 호출 속도가 느려서 발생한 문제..

1. 삭제 성공 여부는 ViewModel의 deleteSuccess로 통일해서 듣고
2. RecordListFragment에서는 이 Flow를 collect 해서 달력/리스트를 다시 조회
3. BottomSheetRecordDeleteFragment에서는 성공 신호 들어오면 그냥 닫기만 하는 구조로 정리
하는 식으로 수정

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **개선사항**
  * 레코드 삭제 후 화면 새로고침 로직을 더욱 안정적으로 개선했습니다. 삭제 성공 시 캘린더와 기록 목록이 현재 월 기준으로 정확하게 업데이트됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->