### PR TITLE
[REFACTOR/#165] 기록 상세 조회 시 삭제 버튼 추가

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
@@ -8,6 +8,9 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.bumptech.glide.Glide
 import com.example.momolabfe.R
 import com.example.momolabfe.databinding.FragmentRecordInfoBinding
@@ -17,6 +20,7 @@ import com.example.momolabfe.remote.record.model.RecordGetResponse
 import com.example.momolabfe.remote.record.model.Turbidity
 import com.example.momolabfe.ui.record.viewModel.RecordViewModel
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -70,6 +74,25 @@ class RecordInfoFragment : Fragment() {
                 .addToBackStack(null)
                 .commit()
         }
+
+        binding.deleteBtn.setOnClickListener {
+            if (recordId == -1L) {
+                Log.e("RECORD_INFO_FRAGMENT", "삭제할 recordId가 없습니다.")
+                return@setOnClickListener
+            }
+
+            // 이미 표시된 BottomSheet가 있는지 확인
+            if (parentFragmentManager.findFragmentByTag("BottomSheetRecordDelete") != null) {
+                return@setOnClickListener
+            }
+
+            val bottomSheet = BottomSheetRecordDeleteFragment().apply {
+                arguments = Bundle().apply {
+                    putLong("record_id", recordId)
+                }
+            }
+            bottomSheet.show(parentFragmentManager, "BottomSheetRecordDelete")
+        }
     }
 
     private fun setupObservers() {
@@ -122,6 +145,19 @@ class RecordInfoFragment : Fragment() {
                 } else {
                     binding.ocrImageTitleTv.visibility = View.GONE
                     binding.ocrImageIv.visibility = View.GONE
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.deleteSuccess.collect {
+                        Log.d("RECORD_INFO_FRAGMENT", "deleteSuccess 수신 - 기록 상세 화면 종료")
+
+                        parentFragmentManager.setFragmentResult("record_delete", Bundle())
+                        parentFragmentManager.popBackStack()
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordListFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordListFragment.kt
@@ -254,6 +254,16 @@ class RecordListFragment : Fragment() {
             bottomSheet.show(parentFragmentManager, "BottomSheetRecordDelete")
         }
 
+        parentFragmentManager.setFragmentResultListener("record_delete", viewLifecycleOwner) { _, _ ->
+            Log.d("RECORD_LIST_FRAGMENT", "record_delete 결과 수신 - 캘린더/리스트 재조회")
+
+            val year = visibleMonth.year
+            val monthValue = visibleMonth.monthValue
+
+            viewModel.getCalendar(year, monthValue)
+            viewModel.getRecordList(year, monthValue)
+        }
+
         hideDetailViews()
     }
 

--- a/app/src/main/res/drawable/bg_white_circle.xml
+++ b/app/src/main/res/drawable/bg_white_circle.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/white" />
+    <corners android:radius="30dp" />
+</shape>

--- a/app/src/main/res/layout/fragment_record_info.xml
+++ b/app/src/main/res/layout/fragment_record_info.xml
@@ -58,11 +58,25 @@
                     app:layout_constraintStart_toStartOf="@id/title_tv"
                     app:layout_constraintTop_toBottomOf="@id/title_tv" />
 
+                <ImageButton
+                    android:id="@+id/delete_btn"
+                    android:layout_width="55dp"
+                    android:layout_height="55dp"
+                    android:layout_marginEnd="8dp"
+                    android:background="@drawable/bg_white_circle"
+                    android:padding="14dp"
+                    android:src="@drawable/ic_trash_sv"
+                    android:scaleType="centerInside"
+                    app:layout_constraintEnd_toStartOf="@+id/edit_btn"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent" />
+
+
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/edit_btn"
                     style="@style/Widget.Material3.Button.TextButton"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_height="60dp"
                     android:layout_marginEnd="10dp"
                     android:fontFamily="@font/noto_sans_kr_medium"
                     android:text="수정"


### PR DESCRIPTION
## 📝 작업 내용
현재 캘린더 기록 조회 시에만 하단에 삭제 버튼을 노출하고 있어, 상세 조회 시에도 삭제할 수 있도록 수정

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 기록 삭제 기능 추가 - 기록 상세 화면에 삭제 버튼이 추가되었습니다. 삭제 확인 후 기록 목록과 캘린더가 자동으로 업데이트됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->