### PR TITLE
[Refactor/#162] 기록 조회 시 제수량 경고 표시

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/main/HomeFragment.kt
@@ -133,6 +133,9 @@ class HomeFragment : Fragment() {
 
             val inflater = LayoutInflater.from(requireContext())
 
+            val normalColor = ContextCompat.getColor(requireContext(), R.color.secondary_text)
+            val errorColor = ContextCompat.getColor(requireContext(), R.color.red)
+
             itemList.forEach { item ->
                 val itemBinding = ItemRecentRecordBinding.inflate(inflater, container, false)
 
@@ -145,6 +148,33 @@ class HomeFragment : Fragment() {
                 itemBinding.totalUfTv.text = item.totalUf.let { uf ->
                     String.format(Locale.KOREA, "%dg", uf)
                 }
+
+                // 제수량 검증 로직
+                var sumUf = 0
+                var hasPerExchangeMismatch = false
+
+                item.exchanges.forEach { ex ->
+
+                    if (ex.uf != null) {
+                        sumUf += ex.uf
+                    }
+
+                    val calculatedUf =
+                        if (ex.drainVolume != null && ex.fillVolume != null) ex.drainVolume - ex.fillVolume else null
+
+                    if (ex.uf != null && calculatedUf != null && ex.uf != calculatedUf) {
+                        hasPerExchangeMismatch = true
+                    }
+                }
+
+                val hasTotalMismatch = (sumUf != item.totalUf)
+
+                val isMismatch = hasPerExchangeMismatch || hasTotalMismatch
+
+                // 하나라도 불일치하면 제수량 텍스트를 빨간색으로 표시
+                itemBinding.totalUfTv.setTextColor(
+                    if (isMismatch) errorColor else normalColor
+                )
 
                 val exchangeCount = item.exchanges.size
                 itemBinding.completeTv.text = "${exchangeCount}회차 완료"

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordListFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordListFragment.kt
@@ -364,6 +364,35 @@ class RecordListFragment : Fragment() {
                 binding.totalUfValueTv.text = "${recordItem.totalUf}g"
                 binding.noteContentTv.text = recordItem.notes ?: ""
 
+                // 제수량 검증
+                val normalColor = ContextCompat.getColor(requireContext(), R.color.secondary_text)
+                val errorColor = ContextCompat.getColor(requireContext(), R.color.red)
+
+                var sumUf = 0
+                var hasPerExchangeMismatch = false
+
+                recordItem.exchanges.forEach { ex ->
+
+                    if (ex.uf != null) {
+                        sumUf += ex.uf
+                    }
+
+                    val calculatedUf =
+                        if (ex.drainVolume != null && ex.fillVolume != null) ex.drainVolume - ex.fillVolume else null
+
+                    if (ex.uf != null && calculatedUf != null && ex.uf != calculatedUf) {
+                        hasPerExchangeMismatch = true
+                    }
+                }
+
+                val hasTotalMismatch = (sumUf != recordItem.totalUf)
+
+                val isMismatch = hasPerExchangeMismatch || hasTotalMismatch
+
+                binding.totalUfValueTv.setTextColor(
+                    if (isMismatch) errorColor else normalColor
+                )
+
                 renderExchanges(recordItem.exchanges)
 
             } else {
@@ -408,6 +437,9 @@ class RecordListFragment : Fragment() {
         binding.bloodPressureValueTv.text = "-/-"
         binding.fastingGlucoseValueTv.text = "- mg/dL"
         binding.totalUfValueTv.text = "-g"
+        binding.totalUfValueTv.setTextColor(
+            ContextCompat.getColor(requireContext(), R.color.secondary_text)
+        )
 
         // 비고 내용 초기화
         binding.noteContentTv.text = ""
@@ -450,10 +482,12 @@ class RecordListFragment : Fragment() {
 
         val inflater = LayoutInflater.from(requireContext())
 
+        val normalColor = ContextCompat.getColor(requireContext(), R.color.secondary_text)
+        val errorColor = ContextCompat.getColor(requireContext(), R.color.red)
+
         exchanges.forEach { item ->
             val itemBinding = ItemExchangeDetailBinding.inflate(inflater, container, false)
 
-            // 기존 onBindViewHolder 내용 그대로
             itemBinding.exchangeNumberBadgeTv.text = item.exchangeNo.toString()
             itemBinding.exchangeTimeTv.text = item.exchangeTime.format(
                 DateTimeFormatter.ofPattern("HH:mm", Locale.KOREA)
@@ -463,6 +497,16 @@ class RecordListFragment : Fragment() {
             val drainText = "배액량: ${item.drainVolume}g"
             val fillText = "주입량: ${item.fillVolume}g"
             itemBinding.volumeTv.text = "$drainText | $fillText"
+
+            // 회차별 제수량 검증
+            val calculatedUf =
+                if (item.drainVolume != null && item.fillVolume != null) item.drainVolume - item.fillVolume else null
+
+            if (item.uf != null && calculatedUf != null && item.uf != calculatedUf) {
+                itemBinding.ufValueTv.setTextColor(errorColor)
+            } else {
+                itemBinding.ufValueTv.setTextColor(normalColor)
+            }
 
             container.addView(itemBinding.root)
         }


### PR DESCRIPTION
## 📝 작업 내용
1. 홈에서 최근 기록 데이터 조회 시, 2. 캘린더 기록 조회 시 제수량 경고 표시
## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 용량 데이터의 유효성 검증 기능 추가
  * 검증 결과에 따른 색상 기반 피드백 도입 (정상: 일반색, 오류: 경고색)

* **버그 수정**
  * 교환 항목별 및 총 용량 불일치 감지 로직 개선
  * 홈 화면 및 기록 목록에 검증 상태 시각화 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->