### PR TITLE
[REFACTOR/#179] 캘린더 기록 조회 시 혈압 단위 표시

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordListFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordListFragment.kt
@@ -357,10 +357,10 @@ class RecordListFragment : Fragment() {
 
                 binding.weightValueTv.text = String.format(Locale.KOREA, "%.1fkg", recordItem.weight)
 
-                val bpText = "${recordItem.systolic}/${recordItem.diastolic}"
+                val bpText = "${recordItem.systolic}/${recordItem.diastolic}mmHg"
                 binding.bloodPressureValueTv.text = bpText
 
-                binding.fastingGlucoseValueTv.text = "${recordItem.fastingGlucose} mg/dL"
+                binding.fastingGlucoseValueTv.text = "${recordItem.fastingGlucose}mg/dL"
                 binding.totalUfValueTv.text = "${recordItem.totalUf}g"
                 binding.noteContentTv.text = recordItem.notes ?: ""
 


### PR DESCRIPTION
## 📝 작업 내용
캘린더 기록 조회 시 혈압 단위 표시

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 혈압 및 공복 혈당 표시 형식 개선
  * 혈압 수치에 "mmHg" 단위 표시 추가
  * 공복 혈당 단위 표시 형식 정렬

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->