### PR TITLE
[Refactor/#180] 에러 처리를 LiveData에서 SharedFlow로 변경

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/auth/LoginFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/auth/LoginFragment.kt
@@ -95,17 +95,18 @@ class LoginFragment : Fragment() {
                 return@setOnClickListener
             }
 
-            BottomSheetForgetPasswordFragment().show(parentFragmentManager, "BottomSheetForgetPassword")
+            BottomSheetForgetPasswordFragment().show(
+                parentFragmentManager,
+                "BottomSheetForgetPassword"
+            )
         }
 
         binding.idEt.addTextChangedListener {
             clearError()
-            viewModel.clearError()
         }
 
         binding.passwordEt.addTextChangedListener {
             clearError()
-            viewModel.clearError()
         }
     }
 
@@ -124,10 +125,12 @@ class LoginFragment : Fragment() {
             isPasswordVisible = !isPasswordVisible
 
             if (isPasswordVisible) { // 비밀번호 보이기
-                binding.passwordEt.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
+                binding.passwordEt.inputType =
+                    InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
                 binding.passwordTil.setEndIconDrawable(R.drawable.ic_eye_opened_sv)
             } else { // 비밀번호 숨기기
-                binding.passwordEt.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+                binding.passwordEt.inputType =
+                    InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
                 binding.passwordTil.setEndIconDrawable(R.drawable.ic_eye_closed_sv)
             }
 
@@ -139,23 +142,25 @@ class LoginFragment : Fragment() {
     private fun observeLoginResult() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.loginSuccess.collectLatest {
-                    if (isNavigating) return@collectLatest
-                    isNavigating = true
+                launch {
+                    viewModel.loginSuccess.collectLatest {
+                        if (isNavigating) return@collectLatest
+                        isNavigating = true
 
-                    Log.d("Login", "로그인 성공!")
+                        Log.d("Login", "로그인 성공!")
 
-                    parentFragmentManager.beginTransaction()
-                        .replace(R.id.main_frm, HomeFragment())
-                        .commit()
+                        parentFragmentManager.beginTransaction()
+                            .replace(R.id.main_frm, HomeFragment())
+                            .commit()
+                    }
                 }
-            }
-        }
 
-        viewModel.errorMessage.observe(viewLifecycleOwner) { message ->
-            message?.let {
-                Log.e("Login", "로그인 실패: $it")
-                showError("아이디 또는 비밀번호가 일치하지 않습니다.")
+                launch {
+                    viewModel.errorEvent.collectLatest { message ->
+                        Log.e("Login", "로그인 실패: $message")
+                        showError("아이디 또는 비밀번호가 일치하지 않습니다.")
+                    }
+                }
             }
         }
     }
@@ -168,7 +173,6 @@ class LoginFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        viewModel.clearError()
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/example/momolabfe/ui/auth/LoginFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/auth/LoginFragment.kt
@@ -156,8 +156,8 @@ class LoginFragment : Fragment() {
                 }
 
                 launch {
-                    viewModel.errorEvent.collectLatest { message ->
-                        Log.e("Login", "로그인 실패: $message")
+                    viewModel.errorEvent.collectLatest { errorMsg ->
+                        Log.e("LOGIN_FRAGMENT", "로그인 실패: $errorMsg")
                         showError("아이디 또는 비밀번호가 일치하지 않습니다.")
                     }
                 }

--- a/app/src/main/java/com/example/momolabfe/ui/auth/viewModel/AuthViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/auth/viewModel/AuthViewModel.kt
@@ -3,7 +3,6 @@ package com.example.momolabfe.ui.auth.viewModel
 import android.content.Context
 import android.util.Log
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.momolabfe.BuildConfig
@@ -30,8 +29,8 @@ class AuthViewModel @Inject constructor(
     @ApplicationContext private val appContext: Context
 ) : ViewModel() {
 
-    private val _errorMessage = MutableLiveData<String?>()
-    val errorMessage: LiveData<String?> get() = _errorMessage
+    private val _errorEvent = MutableSharedFlow<String>()
+    val errorEvent = _errorEvent.asSharedFlow()
 
     private val _loginSuccess = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val loginSuccess: SharedFlow<Unit> = _loginSuccess.asSharedFlow()
@@ -47,9 +46,9 @@ class AuthViewModel @Inject constructor(
                 registerFcmTokenAfterLogin()
 
                 _loginSuccess.tryEmit(Unit)
-                _errorMessage.value = null
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "로그인에 실패했습니다."
+                val message = e.localizedMessage ?: "로그인에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -100,8 +99,4 @@ class AuthViewModel @Inject constructor(
 
     // ID 불러오기
     fun getSavedPatientId(): LiveData<String> = prefRepository.getPatientId()
-
-    fun clearError() {
-        _errorMessage.value = null
-    }
 }

--- a/app/src/main/java/com/example/momolabfe/ui/auth/viewModel/AuthViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/auth/viewModel/AuthViewModel.kt
@@ -48,7 +48,7 @@ class AuthViewModel @Inject constructor(
                 _loginSuccess.tryEmit(Unit)
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "로그인에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }

--- a/app/src/main/java/com/example/momolabfe/ui/auth/viewModel/AuthViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/auth/viewModel/AuthViewModel.kt
@@ -29,7 +29,7 @@ class AuthViewModel @Inject constructor(
     @ApplicationContext private val appContext: Context
 ) : ViewModel() {
 
-    private val _errorEvent = MutableSharedFlow<String>()
+    private val _errorEvent = MutableSharedFlow<String>(extraBufferCapacity = 1)
     val errorEvent = _errorEvent.asSharedFlow()
 
     private val _loginSuccess = MutableSharedFlow<Unit>(extraBufferCapacity = 1)

--- a/app/src/main/java/com/example/momolabfe/ui/consult/ConsultFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/ConsultFragment.kt
@@ -399,7 +399,7 @@ class ConsultFragment : Fragment() {
                         errorMsg
                     }
 
-                    Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
+                    Log.e("CONSULT_FRAGMENT", "상담 요약 실패: $msg")
                 }
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/consult/ConsultFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/ConsultFragment.kt
@@ -91,7 +91,6 @@ class ConsultFragment : Fragment() {
 
         currentSessionId = null // 이전 세션 ID 무효화
         viewModel.resetMessages() // 말풍선 / 에이전트 버퍼 모두 초기화
-        viewModel.clearError()
 
         setupRecyclerView()
         setupObservers()
@@ -386,20 +385,22 @@ class ConsultFragment : Fragment() {
             }
         }
 
-        viewModel.errorMessage.observe(viewLifecycleOwner) { errorMsg ->
-            if (errorMsg != null) {
-                hideSummaryDialog()
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.errorEvent.collect { errorMsg ->
+                    hideSummaryDialog()
 
-                val msg = if (waitingSummaryForSessionId != null && navigateToHistoryOnEnd) {
-                    waitingSummaryForSessionId = null
-                    navigateToHistoryOnEnd = false
-                    getString(R.string.summary_error_message)
-                } else {
-                    errorMsg
+                    val msg = if (waitingSummaryForSessionId != null && navigateToHistoryOnEnd) {
+                        // 요약 도중 에러 발생
+                        waitingSummaryForSessionId = null
+                        navigateToHistoryOnEnd = false
+                        getString(R.string.summary_error_message)
+                    } else {
+                        errorMsg
+                    }
+
+                    Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
                 }
-
-                Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
-                viewModel.clearError()
             }
         }
     }

--- a/app/src/main/java/com/example/momolabfe/ui/consult/ConsultHistoryDetailFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/ConsultHistoryDetailFragment.kt
@@ -1,10 +1,10 @@
 package com.example.momolabfe.ui.consult
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
@@ -87,7 +87,7 @@ class ConsultHistoryDetailFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.errorEvent.collect { errorMsg ->
-                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                    Log.e("CONSULT_HISTORY_DETAIL_FRAGMENT", "상담 상세 조회 실패: $errorMsg")
                 }
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/consult/ConsultHistoryDetailFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/ConsultHistoryDetailFragment.kt
@@ -4,8 +4,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.momolabfe.R
 import com.example.momolabfe.databinding.FragmentConsultHistoryDetailBinding
@@ -14,6 +18,7 @@ import com.example.momolabfe.ui.consult.data.ChatMessage
 import com.example.momolabfe.ui.consult.viewModel.ConsultViewModel
 import com.example.momolabfe.remote.consult.model.MessageRole
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import kotlinx.coroutines.launch
 
 class ConsultHistoryDetailFragment : Fragment() {
 
@@ -77,6 +82,14 @@ class ConsultHistoryDetailFragment : Fragment() {
                 )
             }
             chatAdapter.submitList(chatList)
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.errorEvent.collect { errorMsg ->
+                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/example/momolabfe/ui/consult/ConsultHistoryFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/ConsultHistoryFragment.kt
@@ -2,6 +2,7 @@ package com.example.momolabfe.ui.consult
 
 import android.app.AlertDialog
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -89,7 +90,7 @@ class ConsultHistoryFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.errorEvent.collect { errorMsg ->
-                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                    Log.e("CONSULT_HISTORY_FRAGMENT", "상담 목록 조회 실패: $errorMsg")
                 }
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/consult/ConsultHistoryFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/ConsultHistoryFragment.kt
@@ -8,12 +8,16 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.momolabfe.databinding.FragmentConsultHistoryBinding
 import com.example.momolabfe.ui.consult.adapter.ConsultHistoryAdapter
 import com.example.momolabfe.ui.consult.viewModel.ConsultViewModel
 import com.example.momolabfe.R
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import kotlinx.coroutines.launch
 
 class ConsultHistoryFragment : Fragment() {
 
@@ -79,13 +83,14 @@ class ConsultHistoryFragment : Fragment() {
         viewModel.summaryResult.observe(viewLifecycleOwner) { row ->
             if (row == null) return@observe
 
-            viewModel.applySummaryToHistory(row) // 기록 화면에서 재시도한 요약도 이걸로 반영
+            viewModel.applySummaryToHistory(row) // 기록 화면에서 재시도한 요약도 반영
         }
 
-        viewModel.errorMessage.observe(viewLifecycleOwner) { msg ->
-            msg?.let {
-                Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
-                viewModel.clearError()
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.errorEvent.collect { errorMsg ->
+                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
@@ -30,7 +30,7 @@ class ConsultViewModel @Inject constructor(
     private val consultRepository: ConsultRepository
 ) : ViewModel() {
 
-    private val _errorEvent = MutableSharedFlow<String>()
+    private val _errorEvent = MutableSharedFlow<String>(extraBufferCapacity = 1)
     val errorEvent = _errorEvent.asSharedFlow()
 
     private val _startConsult = MutableLiveData<StartConsultResponse>()

--- a/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
@@ -92,7 +92,7 @@ class ConsultViewModel @Inject constructor(
                 }
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "상담 시작 세션 아이디 발급에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }
@@ -165,7 +165,7 @@ class ConsultViewModel @Inject constructor(
                     }
             } catch (e: Exception) {
                 val message = e.localizedMessage ?: "에이전트 대화 중 오류가 발생했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             } finally {
                 isStreaming = false
 
@@ -185,7 +185,7 @@ class ConsultViewModel @Inject constructor(
                 _endConsultSuccess.tryEmit(request.sessionId)
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "상담 종료에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }
@@ -198,7 +198,7 @@ class ConsultViewModel @Inject constructor(
                 _history.value = list
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "상담 기록을 불러오지 못했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }
@@ -224,7 +224,7 @@ class ConsultViewModel @Inject constructor(
                 _messages.value = mapped
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "특정 상담 기록 상세 조회에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }
@@ -241,7 +241,7 @@ class ConsultViewModel @Inject constructor(
                 _deleteSuccess.tryEmit(Unit)
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "특정 세션 상담 기록 삭제에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }
@@ -260,7 +260,7 @@ class ConsultViewModel @Inject constructor(
                 )
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "특정 상담 세션 요약에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
 
                 // 실패해도 상태는 종료로 리셋
                 _summaryUiState.value = _summaryUiState.value.copy(

--- a/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/consult/viewModel/ConsultViewModel.kt
@@ -30,8 +30,8 @@ class ConsultViewModel @Inject constructor(
     private val consultRepository: ConsultRepository
 ) : ViewModel() {
 
-    private val _errorMessage = MutableLiveData<String?>()
-    val errorMessage: LiveData<String?> get() = _errorMessage
+    private val _errorEvent = MutableSharedFlow<String>()
+    val errorEvent = _errorEvent.asSharedFlow()
 
     private val _startConsult = MutableLiveData<StartConsultResponse>()
     val startConsult: LiveData<StartConsultResponse> get() = _startConsult
@@ -91,7 +91,8 @@ class ConsultViewModel @Inject constructor(
                     _agentMessage.value = response.message
                 }
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "상담 시작 세션 아이디 발급에 실패했습니다."
+                val message = e.localizedMessage ?: "상담 시작 세션 아이디 발급에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -163,7 +164,8 @@ class ConsultViewModel @Inject constructor(
                         updateAgentStreamingMessage(buffer)
                     }
             } catch (e: Exception) {
-                _errorMessage.value = e.localizedMessage ?: "에이전트 대화 중 오류가 발생했습니다."
+                val message = e.localizedMessage ?: "에이전트 대화 중 오류가 발생했습니다."
+                _errorEvent.emit(message)
             } finally {
                 isStreaming = false
 
@@ -182,7 +184,8 @@ class ConsultViewModel @Inject constructor(
                 _endConsult.value = response
                 _endConsultSuccess.tryEmit(request.sessionId)
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "상담 종료에 실패했습니다."
+                val message = e.localizedMessage ?: "상담 종료에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -194,7 +197,8 @@ class ConsultViewModel @Inject constructor(
             result.onSuccess { list ->
                 _history.value = list
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "상담 기록을 불러오지 못했습니다."
+                val message = e.localizedMessage ?: "상담 기록을 불러오지 못했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -219,7 +223,8 @@ class ConsultViewModel @Inject constructor(
 
                 _messages.value = mapped
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "특정 상담 기록 상세 조회에 실패했습니다."
+                val message = e.localizedMessage ?: "특정 상담 기록 상세 조회에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -235,7 +240,8 @@ class ConsultViewModel @Inject constructor(
 
                 _deleteSuccess.tryEmit(Unit)
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "특정 세션 상담 기록 삭제에 실패했습니다."
+                val message = e.localizedMessage ?: "특정 세션 상담 기록 삭제에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -253,7 +259,8 @@ class ConsultViewModel @Inject constructor(
                     isSummarizing = false
                 )
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "특정 상담 세션 요약에 실패했습니다."
+                val message = e.localizedMessage ?: "특정 상담 세션 요약에 실패했습니다."
+                _errorEvent.emit(message)
 
                 // 실패해도 상태는 종료로 리셋
                 _summaryUiState.value = _summaryUiState.value.copy(
@@ -424,9 +431,5 @@ class ConsultViewModel @Inject constructor(
         _agentMessage.value = ""
         nextMessageId = 0L
         isStreaming = false
-    }
-
-    fun clearError() {
-        _errorMessage.value = null
     }
 }

--- a/app/src/main/java/com/example/momolabfe/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/main/HomeFragment.kt
@@ -5,10 +5,14 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.example.momolabfe.R
 import com.example.momolabfe.databinding.FragmentHomeBinding
 import com.example.momolabfe.databinding.ItemRecentRecordBinding
@@ -19,6 +23,7 @@ import com.example.momolabfe.ui.record.viewModel.RecordViewModel
 import com.example.momolabfe.ui.setting.SettingFragment
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.time.format.DateTimeFormatter
 import java.util.Date
@@ -244,11 +249,12 @@ class HomeFragment : Fragment() {
             }
         }
 
-        recordViewModel.errorMessage.observe(viewLifecycleOwner) { errorMsg ->
-            if (errorMsg.isNullOrBlank()) return@observe
-            Log.e("HOME_FRAGMENT", errorMsg.toString())
-
-            recordViewModel.clearError()
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                recordViewModel.errorEvent.collect { errorMsg ->
+                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                }
+            }
         }
     }
 
@@ -259,9 +265,11 @@ class HomeFragment : Fragment() {
             }
         }
 
-        educationViewModel.errorMessage.observe(viewLifecycleOwner) { message ->
-            message?.let {
-                Log.e("TodayTip", "오늘의 복막투석 관리 TIP 조회 실패: $it")
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                educationViewModel.errorEvent.collect { errorMsg ->
+                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/momolabfe/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/main/HomeFragment.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -252,7 +251,7 @@ class HomeFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 recordViewModel.errorEvent.collect { errorMsg ->
-                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                    Log.e("HOME_FRAGMENT", "오늘의 요약 조회 실패: $errorMsg")
                 }
             }
         }
@@ -268,7 +267,7 @@ class HomeFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 educationViewModel.errorEvent.collect { errorMsg ->
-                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                    Log.e("HomeFragment", "복막투석 관리 팁 조회 실패: $errorMsg")
                 }
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/main/viewModel/EducationViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/main/viewModel/EducationViewModel.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.viewModelScope
 import com.example.momolabfe.remote.education.model.EducationResponse
 import com.example.momolabfe.remote.education.repository.EducationRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -15,8 +17,8 @@ class EducationViewModel @Inject constructor(
     private val educationRepository: EducationRepository
 ) : ViewModel() {
 
-    private val _errorMessage = MutableLiveData<String?>()
-    val errorMessage: LiveData<String?> get() = _errorMessage
+    private val _errorEvent = MutableSharedFlow<String>()
+    val errorEvent = _errorEvent.asSharedFlow()
 
     private val _getTipResult = MutableLiveData<EducationResponse>()
     val getTipResult: LiveData<EducationResponse> get() = _getTipResult
@@ -28,7 +30,8 @@ class EducationViewModel @Inject constructor(
             result.onSuccess {
                 _getTipResult.value = it
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "오늘의 복막투석 관리 TIP 조회에 실패했습니다."
+                val message = e.localizedMessage ?: "오늘의 복막투석 관리 TIP 조회에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }

--- a/app/src/main/java/com/example/momolabfe/ui/main/viewModel/EducationViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/main/viewModel/EducationViewModel.kt
@@ -17,7 +17,7 @@ class EducationViewModel @Inject constructor(
     private val educationRepository: EducationRepository
 ) : ViewModel() {
 
-    private val _errorEvent = MutableSharedFlow<String>()
+    private val _errorEvent = MutableSharedFlow<String>(extraBufferCapacity = 1)
     val errorEvent = _errorEvent.asSharedFlow()
 
     private val _getTipResult = MutableLiveData<EducationResponse>()

--- a/app/src/main/java/com/example/momolabfe/ui/main/viewModel/EducationViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/main/viewModel/EducationViewModel.kt
@@ -31,7 +31,7 @@ class EducationViewModel @Inject constructor(
                 _getTipResult.value = it
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "오늘의 복막투석 관리 TIP 조회에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordEditFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordEditFragment.kt
@@ -525,12 +525,13 @@ class RecordEditFragment : Fragment() {
             }
         }
 
-        viewModel.errorMessage.observe(viewLifecycleOwner) { errorMsg ->
-            if (errorMsg.isNullOrBlank()) return@observe
-            Log.e("RECORD_EDIT_FRAGMENT", errorMsg.toString())
-
-            viewModel.clearError()
-            binding.saveBtn.isEnabled = true
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.errorEvent.collect { errorMsg ->
+                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                    binding.saveBtn.isEnabled = true
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordEditFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordEditFragment.kt
@@ -528,7 +528,7 @@ class RecordEditFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.errorEvent.collect { errorMsg ->
-                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                    Log.e("RECORD_EDIT_FRAGMENT", "기록 작업 실패: $errorMsg")
                     binding.saveBtn.isEnabled = true
                 }
             }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordEditFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordEditFragment.kt
@@ -522,14 +522,13 @@ class RecordEditFragment : Fragment() {
                         parentFragmentManager.popBackStack()
                     }
                 }
-            }
-        }
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.errorEvent.collect { errorMsg ->
-                    Log.e("RECORD_EDIT_FRAGMENT", "기록 작업 실패: $errorMsg")
-                    binding.saveBtn.isEnabled = true
+                launch {
+                    viewModel.errorEvent.collect { errorMsg ->
+                        Log.e("RECORD_EDIT_FRAGMENT", "기록 작업 실패: $errorMsg")
+                        showError("기록 저장에 실패했습니다. 다시 시도해주세요.")
+                        binding.saveBtn.isEnabled = true
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -169,7 +168,7 @@ class RecordInfoFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.errorEvent.collect { errorMsg ->
-                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                    Log.e("RECORD_INFO_FRAGMENT", "기록 상세 작업 실패: $errorMsg")
                 }
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -165,11 +166,12 @@ class RecordInfoFragment : Fragment() {
             }
         }
 
-        viewModel.errorMessage.observe(viewLifecycleOwner) { errorMsg ->
-            if (errorMsg.isNullOrBlank()) return@observe
-            Log.e("RECORD_INFO_FRAGMENT", errorMsg.toString())
-
-            viewModel.clearError()
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.errorEvent.collect { errorMsg ->
+                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -166,6 +167,7 @@ class RecordInfoFragment : Fragment() {
                 launch {
                     viewModel.errorEvent.collect { errorMsg ->
                         Log.e("RECORD_INFO_FRAGMENT", "기록 상세 작업 실패: $errorMsg")
+                        Toast.makeText(requireContext(), "기록을 불러오는데 실패했습니다.", Toast.LENGTH_SHORT).show()
                     }
                 }
             }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordInfoFragment.kt
@@ -162,13 +162,11 @@ class RecordInfoFragment : Fragment() {
                         parentFragmentManager.popBackStack()
                     }
                 }
-            }
-        }
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.errorEvent.collect { errorMsg ->
-                    Log.e("RECORD_INFO_FRAGMENT", "기록 상세 작업 실패: $errorMsg")
+                launch {
+                    viewModel.errorEvent.collect { errorMsg ->
+                        Log.e("RECORD_INFO_FRAGMENT", "기록 상세 작업 실패: $errorMsg")
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordListFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordListFragment.kt
@@ -11,7 +11,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.TextView
-import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -429,7 +428,7 @@ class RecordListFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.errorEvent.collect { errorMsg ->
-                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                    Log.e("RECORD_LIST_FRAGMENT", "기록 목록 작업 실패: $errorMsg")
                 }
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordListFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordListFragment.kt
@@ -422,13 +422,11 @@ class RecordListFragment : Fragment() {
                         renderExchanges(emptyList())
                     }
                 }
-            }
-        }
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.errorEvent.collect { errorMsg ->
-                    Log.e("RECORD_LIST_FRAGMENT", "기록 목록 작업 실패: $errorMsg")
+                launch {
+                    viewModel.errorEvent.collect { errorMsg ->
+                        Log.e("RECORD_LIST_FRAGMENT", "기록 목록 작업 실패: $errorMsg")
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordListFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordListFragment.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.TextView
+import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -425,11 +426,12 @@ class RecordListFragment : Fragment() {
             }
         }
 
-        viewModel.errorMessage.observe(viewLifecycleOwner) { errorMsg ->
-            if (errorMsg.isNullOrBlank()) return@observe
-            Log.e("RECORD_LIST_FRAGMENT", errorMsg.toString())
-
-            viewModel.clearError()
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.errorEvent.collect { errorMsg ->
+                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordOcrLoadingFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordOcrLoadingFragment.kt
@@ -2,6 +2,7 @@ package com.example.momolabfe.ui.record
 
 import android.animation.ObjectAnimator
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -196,13 +197,13 @@ class RecordOcrLoadingFragment : Fragment() {
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.errorEvent.collect { msg ->
+                viewModel.errorEvent.collect { errorMsg ->
                     if (!navigated) {
                         isOcrFinished = true
                         navigated = true
                         loadingJob?.cancel()
 
-                        Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
+                        Log.e("RECORD_OCR_LOADING_FRAGMENT", "OCR 인식 실패: $errorMsg")
                         parentFragmentManager.popBackStack()
                     }
                 }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordOcrLoadingFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordOcrLoadingFragment.kt
@@ -17,7 +17,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import androidx.core.net.toUri
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.example.momolabfe.ui.record.data.LoadingStep
 import com.example.momolabfe.ui.record.viewModel.RecordViewModel
 import kotlinx.coroutines.isActive
@@ -192,15 +194,18 @@ class RecordOcrLoadingFragment : Fragment() {
             }
         }
 
-        viewModel.errorMessage.observe(viewLifecycleOwner) { msg ->
-            if (!msg.isNullOrBlank() && !navigated) {
-                isOcrFinished = true
-                navigated = true
-                loadingJob?.cancel()
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.errorEvent.collect { msg ->
+                    if (!navigated) {
+                        isOcrFinished = true
+                        navigated = true
+                        loadingJob?.cancel()
 
-                Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
-                parentFragmentManager.popBackStack()
-                viewModel.clearError()
+                        Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
+                        parentFragmentManager.popBackStack()
+                    }
+                }
             }
         }
     }
@@ -231,6 +236,7 @@ class RecordOcrLoadingFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        loadingJob?.cancel()
         _binding = null
     }
 }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordOcrLoadingFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordOcrLoadingFragment.kt
@@ -204,6 +204,7 @@ class RecordOcrLoadingFragment : Fragment() {
                         loadingJob?.cancel()
 
                         Log.e("RECORD_OCR_LOADING_FRAGMENT", "OCR 인식 실패: $errorMsg")
+                        Toast.makeText(requireContext(), "OCR 인식에 실패했습니다.", Toast.LENGTH_SHORT).show()
                         parentFragmentManager.popBackStack()
                     }
                 }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
@@ -458,28 +458,28 @@ class RecordWrite02Fragment : Fragment() {
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.recordSuccess.collectLatest {
-                    // 기록 저장 성공 시에만 OCR 상태 정리
-                    viewModel.clearOcr()
+                launch {
+                    viewModel.recordSuccess.collectLatest {
+                        // 기록 저장 성공 시에만 OCR 상태 정리
+                        viewModel.clearOcr()
 
-                    // 기존 백스택 다 비우기
-                    parentFragmentManager.popBackStack(
-                        null,
-                        FragmentManager.POP_BACK_STACK_INCLUSIVE
-                    )
+                        // 기존 백스택 다 비우기
+                        parentFragmentManager.popBackStack(
+                            null,
+                            FragmentManager.POP_BACK_STACK_INCLUSIVE
+                        )
 
-                    parentFragmentManager.beginTransaction()
-                        .replace(R.id.main_frm, HomeFragment())
-                        .commit()
+                        parentFragmentManager.beginTransaction()
+                            .replace(R.id.main_frm, HomeFragment())
+                            .commit()
+                    }
                 }
-            }
-        }
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.errorEvent.collect { errorMsg ->
-                    Log.e("RECORD_WRITE_FRAGMENT", "기록 작성 실패: $errorMsg")
-                    binding.saveBtn.isEnabled = true
+                launch {
+                    viewModel.errorEvent.collect { errorMsg ->
+                        Log.e("RECORD_WRITE_FRAGMENT", "기록 작성 실패: $errorMsg")
+                        binding.saveBtn.isEnabled = true
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
@@ -474,12 +474,14 @@ class RecordWrite02Fragment : Fragment() {
                 }
             }
         }
-        viewModel.errorMessage.observe(viewLifecycleOwner) { errorMsg ->
-            if (errorMsg.isNullOrBlank()) return@observe
-            Log.e("RECORD_WRITE_02_FRAGMENT", errorMsg.toString())
 
-            viewModel.clearError()
-            binding.saveBtn.isEnabled = true
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.errorEvent.collect { errorMsg ->
+                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                    binding.saveBtn.isEnabled = true
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
@@ -478,6 +478,7 @@ class RecordWrite02Fragment : Fragment() {
                 launch {
                     viewModel.errorEvent.collect { errorMsg ->
                         Log.e("RECORD_WRITE_FRAGMENT", "기록 작성 실패: $errorMsg")
+                        showError("기록 저장에 실패했습니다. 다시 시도해주세요.")
                         binding.saveBtn.isEnabled = true
                     }
                 }

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
@@ -459,7 +459,7 @@ class RecordWrite02Fragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
-                    viewModel.recordSuccess.collectLatest {
+                    viewModel.recordSuccess.collect {
                         // 기록 저장 성공 시에만 OCR 상태 정리
                         viewModel.clearOcr()
 

--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite02Fragment.kt
@@ -478,7 +478,7 @@ class RecordWrite02Fragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.errorEvent.collect { errorMsg ->
-                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                    Log.e("RECORD_WRITE_FRAGMENT", "기록 작성 실패: $errorMsg")
                     binding.saveBtn.isEnabled = true
                 }
             }

--- a/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
@@ -25,8 +25,8 @@ class RecordViewModel @Inject constructor(
     private val recordRepository: RecordRepository
 ) : ViewModel() {
 
-    private val _errorMessage = MutableLiveData<String?>()
-    val errorMessage: LiveData<String?> get() = _errorMessage
+    private val _errorEvent = MutableSharedFlow<String>()
+    val errorEvent = _errorEvent.asSharedFlow()
 
     // 교환 시간 (24시간 형식, 서버 전송용)
     private val _exchangeTime = MutableLiveData<String>()
@@ -73,7 +73,8 @@ class RecordViewModel @Inject constructor(
             result.onSuccess { calendarList ->
                 _calendarData.value = calendarList
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "캘린더 조회에 실패했습니다."
+                val message = e.localizedMessage ?: "캘린더 조회에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -85,7 +86,8 @@ class RecordViewModel @Inject constructor(
             result.onSuccess {
                 _recordSuccess.tryEmit(Unit)
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "기록 작성에 실패했습니다."
+                val message = e.localizedMessage ?: "기록 작성에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -97,7 +99,8 @@ class RecordViewModel @Inject constructor(
             result.onSuccess {
                 _recordSuccess.tryEmit(Unit)
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "기록 수정에 실패했습니다."
+                val message = e.localizedMessage ?: "기록 수정에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -109,7 +112,8 @@ class RecordViewModel @Inject constructor(
             result.onSuccess { list ->
                 _recordlistItems.value = list
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "전체 기록 조회에 실패했습니다."
+                val message = e.localizedMessage ?: "전체 기록 조회에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -121,7 +125,8 @@ class RecordViewModel @Inject constructor(
             result.onSuccess {
                 _record.value = it
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "특정 기록 조회에 실패했습니다."
+                val message = e.localizedMessage ?: "특정 기록 조회에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -133,7 +138,8 @@ class RecordViewModel @Inject constructor(
             result.onSuccess { list ->
                 _recordlistItems.value = list
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "최근 3개 기록 조회에 실패했습니다."
+                val message = e.localizedMessage ?: "최근 3개 기록 조회에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -145,7 +151,8 @@ class RecordViewModel @Inject constructor(
             result.onSuccess { weeklyAvgData ->
                 _weeklyAverageData.value = weeklyAvgData
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "주간 평균 기록 조회에 실패했습니다."
+                val message = e.localizedMessage ?: "주간 평균 기록 조회에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -157,7 +164,8 @@ class RecordViewModel @Inject constructor(
             result.onSuccess { summary ->
                 _todayExchangeSummary.value = summary
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "오늘의 요약 조회에 실패했습니다."
+                val message = e.localizedMessage ?: "오늘의 요약 조회에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -169,7 +177,8 @@ class RecordViewModel @Inject constructor(
             result.onSuccess {
                 _deleteSuccess.tryEmit(Unit)
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "특정 기록 삭제에 실패했습니다."
+                val message = e.localizedMessage ?: "특정 기록 삭제에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -183,7 +192,8 @@ class RecordViewModel @Inject constructor(
             result.onSuccess {
                 _ocrRecordResult.value = it
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "OCR 텍스트 추출에 실패했습니다."
+                val message = e.localizedMessage ?: "OCR 텍스트 추출에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -194,10 +204,5 @@ class RecordViewModel @Inject constructor(
 
     fun clearOcr() {
         _ocrRecordResult.value = null
-        _errorMessage.value = null
-    }
-
-    fun clearError() {
-        _errorMessage.value = null
     }
 }

--- a/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
@@ -25,7 +25,7 @@ class RecordViewModel @Inject constructor(
     private val recordRepository: RecordRepository
 ) : ViewModel() {
 
-    private val _errorEvent = MutableSharedFlow<String>()
+    private val _errorEvent = MutableSharedFlow<String>(extraBufferCapacity = 1)
     val errorEvent = _errorEvent.asSharedFlow()
 
     // 교환 시간 (24시간 형식, 서버 전송용)

--- a/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/viewModel/RecordViewModel.kt
@@ -74,7 +74,7 @@ class RecordViewModel @Inject constructor(
                 _calendarData.value = calendarList
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "캘린더 조회에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }
@@ -87,7 +87,7 @@ class RecordViewModel @Inject constructor(
                 _recordSuccess.tryEmit(Unit)
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "기록 작성에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }
@@ -100,7 +100,7 @@ class RecordViewModel @Inject constructor(
                 _recordSuccess.tryEmit(Unit)
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "기록 수정에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }
@@ -113,7 +113,7 @@ class RecordViewModel @Inject constructor(
                 _recordlistItems.value = list
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "전체 기록 조회에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }
@@ -126,7 +126,7 @@ class RecordViewModel @Inject constructor(
                 _record.value = it
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "특정 기록 조회에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }
@@ -139,7 +139,7 @@ class RecordViewModel @Inject constructor(
                 _recordlistItems.value = list
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "최근 3개 기록 조회에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }
@@ -152,7 +152,7 @@ class RecordViewModel @Inject constructor(
                 _weeklyAverageData.value = weeklyAvgData
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "주간 평균 기록 조회에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }
@@ -165,7 +165,7 @@ class RecordViewModel @Inject constructor(
                 _todayExchangeSummary.value = summary
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "오늘의 요약 조회에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }
@@ -178,7 +178,7 @@ class RecordViewModel @Inject constructor(
                 _deleteSuccess.tryEmit(Unit)
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "특정 기록 삭제에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }
@@ -193,7 +193,7 @@ class RecordViewModel @Inject constructor(
                 _ocrRecordResult.value = it
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "OCR 텍스트 추출에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }

--- a/app/src/main/java/com/example/momolabfe/ui/setting/CustomerEmergencyFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/CustomerEmergencyFragment.kt
@@ -6,11 +6,16 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.example.momolabfe.databinding.FragmentCustomerEmergencyBinding
 import com.example.momolabfe.ui.setting.viewModel.SettingViewModel
+import kotlinx.coroutines.launch
 
 class CustomerEmergencyFragment : Fragment() {
 
@@ -49,15 +54,16 @@ class CustomerEmergencyFragment : Fragment() {
             }
         }
 
-        viewModel.errorMessage.observe(viewLifecycleOwner) { message ->
-            message?.let {
-                Log.e("HospitalInfo", "자주 가는 병원 조회 실패: $it")
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.errorEvent.collect { errorMsg ->
+                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }
 
     override fun onDestroyView() {
-        viewModel.clearError()
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/example/momolabfe/ui/setting/CustomerEmergencyFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/CustomerEmergencyFragment.kt
@@ -6,7 +6,6 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -57,7 +56,7 @@ class CustomerEmergencyFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.errorEvent.collect { errorMsg ->
-                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                    Log.e("CUSTOMER_EMERGENCY_FRAGMENT", "자주 가는 병원 조회 실패: $errorMsg")
                 }
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/setting/PasswordFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/PasswordFragment.kt
@@ -154,9 +154,13 @@ class PasswordFragment : Fragment() {
             }
         }
 
-        viewModel.errorMessage.observe(viewLifecycleOwner) { errorMsg ->
-            Log.e("PASSWORD_FRAGMENT", errorMsg.toString())
-            binding.changeBtn.isEnabled = true
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.errorEvent.collect { errorMsg ->
+                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                    binding.changeBtn.isEnabled = true
+                }
+            }
         }
     }
 
@@ -172,7 +176,6 @@ class PasswordFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        viewModel.clearError()
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/example/momolabfe/ui/setting/PasswordFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/PasswordFragment.kt
@@ -151,14 +151,13 @@ class PasswordFragment : Fragment() {
                         parentFragmentManager.popBackStack()
                     }
                 }
-            }
-        }
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.errorEvent.collect { errorMsg ->
-                    Log.e("PASSWORD_FRAGMENT", "비밀번호 재설정 실패: $errorMsg")
-                    binding.changeBtn.isEnabled = true
+                launch {
+                    viewModel.errorEvent.collect { errorMsg ->
+                        Log.e("PASSWORD_FRAGMENT", "비밀번호 재설정 실패: $errorMsg")
+                        showError("비밀번호 변경에 실패했습니다.")
+                        binding.changeBtn.isEnabled = true
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/setting/PasswordFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/PasswordFragment.kt
@@ -157,7 +157,7 @@ class PasswordFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.errorEvent.collect { errorMsg ->
-                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                    Log.e("PASSWORD_FRAGMENT", "비밀번호 재설정 실패: $errorMsg")
                     binding.changeBtn.isEnabled = true
                 }
             }

--- a/app/src/main/java/com/example/momolabfe/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/SettingFragment.kt
@@ -5,9 +5,12 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.example.momolabfe.R
 import com.example.momolabfe.databinding.FragmentSettingBinding
 import com.example.momolabfe.remote.auth.LogoutManager
@@ -129,11 +132,12 @@ class SettingFragment : Fragment() {
             }
         }
 
-        viewModel.errorMessage.observe(viewLifecycleOwner) { message ->
-            if (message.isNullOrBlank()) return@observe
-            Log.e("MyPage", "마이페이지 조회 실패: $message")
-
-            viewModel.clearError()
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.errorEvent.collect { errorMsg ->
+                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/example/momolabfe/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/SettingFragment.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
@@ -135,7 +134,7 @@ class SettingFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.errorEvent.collect { errorMsg ->
-                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                    Log.e("SETTING_FRAGMENT", "환자 정보 실패: $errorMsg")
                 }
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/setting/viewModel/SettingViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/viewModel/SettingViewModel.kt
@@ -20,8 +20,8 @@ class SettingViewModel @Inject constructor(
     private val userRepository: UserRepository
 ) : ViewModel() {
 
-    private val _errorMessage = MutableLiveData<String?>()
-    val errorMessage: LiveData<String?> get() = _errorMessage
+    private val _errorEvent = MutableSharedFlow<String>()
+    val errorEvent = _errorEvent.asSharedFlow()
 
     private val _passwordSuccess = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val passwordSuccess: SharedFlow<Unit> = _passwordSuccess.asSharedFlow()
@@ -42,7 +42,8 @@ class SettingViewModel @Inject constructor(
             result.onSuccess {
                 _getPageResult.value = it
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "마이페이지 조회에 실패했습니다."
+                val message = e.localizedMessage ?: "마이페이지 조회에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -54,7 +55,8 @@ class SettingViewModel @Inject constructor(
             result.onSuccess {
                 _passwordSuccess.tryEmit(Unit)
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "비밀번호 재설정에 실패했습니다."
+                val message = e.localizedMessage ?: "비밀번호 재설정에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
     }
@@ -66,12 +68,9 @@ class SettingViewModel @Inject constructor(
             result.onSuccess {
                 _getHospitalResult.value = it
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "자주 가는 병원 조회에 실패했습니다."
+                val message = e.localizedMessage ?: "자주 가는 병원 조회에 실패했습니다."
+                _errorEvent.emit(message)
             }
         }
-    }
-
-    fun clearError() {
-        _errorMessage.value = null
     }
 }

--- a/app/src/main/java/com/example/momolabfe/ui/setting/viewModel/SettingViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/viewModel/SettingViewModel.kt
@@ -43,7 +43,7 @@ class SettingViewModel @Inject constructor(
                 _getPageResult.value = it
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "마이페이지 조회에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }
@@ -56,7 +56,7 @@ class SettingViewModel @Inject constructor(
                 _passwordSuccess.tryEmit(Unit)
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "비밀번호 재설정에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }
@@ -69,7 +69,7 @@ class SettingViewModel @Inject constructor(
                 _getHospitalResult.value = it
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "자주 가는 병원 조회에 실패했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }

--- a/app/src/main/java/com/example/momolabfe/ui/setting/viewModel/SettingViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/viewModel/SettingViewModel.kt
@@ -21,7 +21,7 @@ class SettingViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val _errorEvent = MutableSharedFlow<String>(extraBufferCapacity = 1)
-    val errorEvent = _errorEvent.asSharedFlow()
+    val errorEvent: SharedFlow<String> = _errorEvent.asSharedFlow()
 
     private val _passwordSuccess = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val passwordSuccess: SharedFlow<Unit> = _passwordSuccess.asSharedFlow()

--- a/app/src/main/java/com/example/momolabfe/ui/setting/viewModel/SettingViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/setting/viewModel/SettingViewModel.kt
@@ -20,7 +20,7 @@ class SettingViewModel @Inject constructor(
     private val userRepository: UserRepository
 ) : ViewModel() {
 
-    private val _errorEvent = MutableSharedFlow<String>()
+    private val _errorEvent = MutableSharedFlow<String>(extraBufferCapacity = 1)
     val errorEvent = _errorEvent.asSharedFlow()
 
     private val _passwordSuccess = MutableSharedFlow<Unit>(extraBufferCapacity = 1)

--- a/app/src/main/java/com/example/momolabfe/ui/stats/StatsFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/stats/StatsFragment.kt
@@ -8,6 +8,9 @@ import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.example.momolabfe.R
 import com.example.momolabfe.databinding.FragmentStatsBinding
 import com.example.momolabfe.remote.stats.model.Last7DaysStats
@@ -24,10 +27,13 @@ import com.github.mikephil.charting.data.LineData
 import com.github.mikephil.charting.data.LineDataSet
 import com.github.mikephil.charting.formatter.ValueFormatter
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlin.math.roundToInt
 
+@AndroidEntryPoint
 class StatsFragment : Fragment() {
 
     private var _binding: FragmentStatsBinding? = null
@@ -59,10 +65,11 @@ class StatsFragment : Fragment() {
             bindStats(stats)
         }
 
-        viewModel.errorMessage.observe(viewLifecycleOwner) { msg ->
-            if (msg != null) {
-                Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
-                viewModel.clearError()
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.errorEvent.collect { errorMsg ->
+                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }
@@ -322,7 +329,6 @@ class StatsFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        viewModel.clearError()
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/example/momolabfe/ui/stats/StatsFragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/stats/StatsFragment.kt
@@ -1,10 +1,10 @@
 package com.example.momolabfe.ui.stats
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -68,7 +68,7 @@ class StatsFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.errorEvent.collect { errorMsg ->
-                    Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+                    Log.e("STATS_FRAGMENT", "통계 조회 실패: $errorMsg")
                 }
             }
         }

--- a/app/src/main/java/com/example/momolabfe/ui/stats/viewModel/StatsViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/stats/viewModel/StatsViewModel.kt
@@ -17,7 +17,7 @@ class StatsViewModel @Inject constructor(
     private val statsRepository: StatsRepository
 ) : ViewModel() {
 
-    private val _errorEvent = MutableSharedFlow<String>()
+    private val _errorEvent = MutableSharedFlow<String>(extraBufferCapacity = 1)
     val errorEvent = _errorEvent.asSharedFlow()
 
     private val _getStatsResult = MutableLiveData<Last7DaysStats>()

--- a/app/src/main/java/com/example/momolabfe/ui/stats/viewModel/StatsViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/stats/viewModel/StatsViewModel.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.viewModelScope
 import com.example.momolabfe.remote.stats.model.Last7DaysStats
 import com.example.momolabfe.remote.stats.repository.StatsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -15,8 +17,8 @@ class StatsViewModel @Inject constructor(
     private val statsRepository: StatsRepository
 ) : ViewModel() {
 
-    private val _errorMessage = MutableLiveData<String?>()
-    val errorMessage: LiveData<String?> get() = _errorMessage
+    private val _errorEvent = MutableSharedFlow<String>()
+    val errorEvent = _errorEvent.asSharedFlow()
 
     private val _getStatsResult = MutableLiveData<Last7DaysStats>()
     val getStatsResult: LiveData<Last7DaysStats> get() = _getStatsResult
@@ -27,12 +29,9 @@ class StatsViewModel @Inject constructor(
             result.onSuccess { list ->
                 _getStatsResult.value = list
             }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "최근 7일간의 통계를 불러오지 못했습니다."
+                val message = e.localizedMessage ?: "최근 7일간의 통계를 불러오지 못했습니다."
+                _errorEvent.emit(message)
             }
         }
-    }
-
-    fun clearError() {
-        _errorMessage.value = null
     }
 }

--- a/app/src/main/java/com/example/momolabfe/ui/stats/viewModel/StatsViewModel.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/stats/viewModel/StatsViewModel.kt
@@ -30,7 +30,7 @@ class StatsViewModel @Inject constructor(
                 _getStatsResult.value = list
             }.onFailure { e ->
                 val message = e.localizedMessage ?: "최근 7일간의 통계를 불러오지 못했습니다."
-                _errorEvent.emit(message)
+                _errorEvent.tryEmit(message)
             }
         }
     }

--- a/app/src/main/res/layout/fragment_onboarding.xml
+++ b/app/src/main/res/layout/fragment_onboarding.xml
@@ -10,7 +10,7 @@
         android:id="@+id/skip_tv"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="60dp"
+        android:layout_marginTop="40dp"
         android:text="건너뛰기"
         android:textSize="14sp"
         android:textColor="#A0A4B0"


### PR DESCRIPTION
## 📝 작업 내용
에러 처리를 LiveData에서 SharedFlow로 변경하여 1회성 이벤트로 처리합니다.

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 온보딩 화면 스킵 버튼 상단 여백 감소(60dp → 40dp)

* **Refactor**
  * 앱 전반의 오류 처리 방식을 LiveData→lifecycle-aware Flow로 전환해 수명주기 안전성 및 일관된 로깅/표시 개선
  * 뷰 해제 시 명시적 오류 초기화 제거로 정리 동작 간소화
  * 통계 화면에 의존성 주입 및 수명주기 처리 개선으로 안정성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->