### PR TITLE
[BUG/#178] 기록 작성 취소 다이얼로그가 이전 화면에서도 노출되는 문제

### DIFF
--- a/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite01Fragment.kt
+++ b/app/src/main/java/com/example/momolabfe/ui/record/RecordWrite01Fragment.kt
@@ -71,6 +71,8 @@ class RecordWrite01Fragment : Fragment() {
         arguments?.getBoolean("fromOcr", false) ?: false
     }
 
+    private lateinit var backCallback: OnBackPressedCallback // 콜백 변수
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -90,14 +92,13 @@ class RecordWrite01Fragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        requireActivity().onBackPressedDispatcher.addCallback(
-            this,
-            object : OnBackPressedCallback(true) {
-                override fun handleOnBackPressed() {
-                    showBackConfirmDialog()
-                }
+        backCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                showBackConfirmDialog()
             }
-        )
+        }
+
+        requireActivity().onBackPressedDispatcher.addCallback(this, backCallback)
     }
 
     private fun showBackConfirmDialog() {
@@ -110,6 +111,8 @@ class RecordWrite01Fragment : Fragment() {
             }
             .setPositiveButton("예") { dialog, _ ->
                 dialog.dismiss()
+                backCallback.isEnabled = false
+
                 viewModel.clearOcr()
                 parentFragmentManager.popBackStack()
             }


### PR DESCRIPTION
## 📝 작업 내용
기록 작성 도중 뒤로 가기 -> "기록 작성을 취소하시겠습니까?" 다이얼로그 노출되며 이때 "예" 클릭 시 이전 화면으로 돌아옴, 그런데 뒤로 가기 클릭하면 다이얼로그가 또 다시 노출되는 문제 해결

## 📸 스크린샷 (에뮬레이터: Pixel 8a, 시연 기기: Galaxy S22+)
> 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 기록 작성 화면에서 뒤로 가기 버튼 동작이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->